### PR TITLE
schema-with-name

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -213,19 +213,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public: miscellaneous macros and helpers
 
-(clojure.core/defn schema-with-name [schema name]
-  "Records name in schema's metadata."
-  (with-meta schema {:name name}))
-
-(clojure.core/defn schema-name [schema]
-  "Returns the name of a schema defined via defschema."
-  (-> schema meta :name))
-
 (defmacro defschema
   "Convenience macro to make it clear to reader that body is meant to be used as a schema.
    The name of the schema is recorded in the metadata."
   [name form]
-  `(def ~name (schema-with-name ~form '~name)))
+  `(def ~name (schema.core/schema-with-name ~form '~name)))
 
 ;;; The clojure version is a function in schema.core, this must be here for cljs because
 ;;; satisfies? is a macro that must have access to the protocol at compile-time.

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -321,9 +321,6 @@
   [pred if-schema else-schema]
   (conditional pred if-schema (constantly true) else-schema))
 
-;; Useful for documenting that a def is a schema. Returns a NamedSchema.
-#+clj (potemkin/import-vars macros/defschema)
-
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Map Schemas
 
@@ -709,9 +706,7 @@
    macros/defrecord
    macros/fn
    macros/defn
-   macros/with-fn-validation
-   macros/schema-name
-   macros/schema-with-name)
+   macros/with-fn-validation)
   (reset! macros/*use-potemkin* true) ;; Use potemkin for s/defrecord by default.
   (set! *warn-on-reflection* false))
 
@@ -721,3 +716,17 @@
   (macros/assert-iae (fn? f) "Non-function %s" (utils/type-of f))
   (or (utils/class-schema (utils/type-of f))
       (utils/safe-get (meta f) :schema)))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Helpers for defining schemas (used in in-progress work, explanation coming soon)
+
+(defn schema-with-name [schema name]
+  "Records name in schema's metadata."
+  (with-meta schema {:name name}))
+
+(defn schema-name [schema]
+  "Returns the name of a schema attached via schema-with-name (or defschema)."
+  (-> schema meta :name))
+
+#+clj (potemkin/import-vars macros/defschema)

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -746,18 +746,18 @@
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Convenience functions
+;;;  Helpers for defining schemas (used in in-progress work, expanlation coming soon)
 
-(sm/defschema TestFoo {:bar String})
+(sm/defschema TestFoo {:bar s/String})
 
 (deftest test-defschema
   (is (= 'TestFoo (:name (meta TestFoo)))))
 
 (deftest schema-with-name-test
-  (let [schema (sm/schema-with-name {:baz Number} 'Baz)]
+  (let [schema (s/schema-with-name {:baz s/Number} 'Baz)]
     (valid! schema {:baz 123})
     (invalid! schema {:baz "abc"})
-    (is (= 'Baz (-> schema meta :name)))))
+    (is (= 'Baz (s/schema-name schema)))))
 
 (deftest schema-name-test
-  (is (= 'TestFoo (sm/schema-name TestFoo))))
+  (is (= 'TestFoo (s/schema-name TestFoo))))


### PR DESCRIPTION
@w01fe 

Undo the wrapping of `defschema` in `NamedSchema`; just put the name in the schema's metadata.
