### PR TITLE
Better stack traces

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -14,7 +14,7 @@
   "Like assert, but throws an IllegalArgumentException and takes args to format"
   [form & format-args]
   `(when-not ~form
-     (utils/error! ~@format-args)))
+     (utils/error! (apply format ~format-args))))
 
 (defmacro validation-error [schema value expectation & [fail-explanation]]
   `(utils/->ValidationError ~schema ~value (delay ~expectation) ~fail-explanation))
@@ -171,13 +171,13 @@
                                                 ~(if rest-arg
                                                    `(list* ~@bind-syms ~rest-sym)
                                                    bind-syms))]
-                               (utils/error! "Input to %s does not match schema: %s"
-                                             '~fn-name (pr-str error#))))
+                               (utils/error! (format "Input to %s does not match schema: %s"
+                                                     '~fn-name (pr-str error#)))))
                            (let [o# (do ~@body)]
                              (when validate#
                                (when-let [error# (schema.core/check ~output-schema-sym o#)]
-                                 (utils/error! "Output of %s does not match schema: %s"
-                                               '~fn-name (pr-str error#))))
+                                 (utils/error! (format "Output of %s does not match schema: %s"
+                                                       '~fn-name (pr-str error#)))))
                              o#)))))
                    (cons bind body))}))
 
@@ -338,9 +338,9 @@
                    " keys are required, and no extra keys are allowed.  Even faster than map->")
              [~map-sym & [drop-extra-keys?#]]
              (when-not (or drop-extra-keys?# (= (count ~map-sym) ~(count field-schema)))
-               (utils/error! "Record has wrong set of keys: %s"
-                             (data/diff (set (keys ~map-sym))
-                                        ~(set (map keyword field-schema)))))
+               (utils/error! (format "Record has wrong set of keys: %s"
+                                     (data/diff (set (keys ~map-sym))
+                                                ~(set (map keyword field-schema))))))
              (new ~(symbol (str name))
                   ~@(map (clojure.core/fn [s] `(utils/safe-get ~map-sym ~(keyword s))) field-schema)))))))
 
@@ -438,5 +438,3 @@
   `(do
      (.set_cell utils/use-fn-validation true)
      (try ~@body (finally (.set_cell utils/use-fn-validation false)))))
-
-(schema.core/defn foo :- String [x] x)

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -128,7 +128,7 @@
   "Throw an exception if value does not satisfy schema; otherwise, return value."
   [schema value]
   (when-let [error (check schema value)]
-    (utils/error! "Value does not match schema: %s" (pr-str error)))
+    (utils/error! (format "Value does not match schema: %s" (pr-str error))))
   value)
 
 
@@ -289,7 +289,7 @@
   ([p?] (pred p? p?))
   ([p? pred-name]
      (when-not (fn? p?)
-       (utils/error! "Not a function: %s" p?))
+       (utils/error! (format "Not a function: %s" p?)))
      (Predicate. p? pred-name)))
 
 
@@ -372,7 +372,7 @@
   (cond (keyword? ks) ks
         (instance? RequiredKey ks) (.-k ^RequiredKey ks)
         (instance? OptionalKey ks) (.-k ^OptionalKey ks)
-        :else (utils/error! "Bad explicit key: %s" ks)))
+        :else (utils/error! (format "Bad explicit key: %s" ks))))
 
 (defn- specific-key? [ks]
   (or (required-key? ks)
@@ -710,7 +710,7 @@
   (reset! macros/*use-potemkin* true) ;; Use potemkin for s/defrecord by default.
   (set! *warn-on-reflection* false))
 
-(defn ^FnSchema fn-schema
+(clojure.core/defn ^FnSchema fn-schema
   "Produce the schema for a function defined with s/fn or s/defn."
   [f]
   (macros/assert-iae (fn? f) "Non-function %s" (utils/type-of f))
@@ -721,11 +721,11 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Helpers for defining schemas (used in in-progress work, explanation coming soon)
 
-(defn schema-with-name [schema name]
+(clojure.core/defn schema-with-name [schema name]
   "Records name in schema's metadata."
   (with-meta schema {:name name}))
 
-(defn schema-name [schema]
+(clojure.core/defn schema-name [schema]
   "Returns the name of a schema attached via schema-with-name (or defschema)."
   (-> schema meta :name))
 

--- a/src/cljx/schema/utils.cljx
+++ b/src/cljx/schema/utils.cljx
@@ -14,22 +14,22 @@
               :when v]
           [k v])))
 
-(clojure.core/defn type-of [x]
+(defn type-of [x]
   #+clj (class x)
   #+cljs (js* "typeof ~{}" x))
 
-#+clj (defmacro error! [& format-args]
-        `(throw (RuntimeException. ^String (format ~@format-args))))
+#+clj (defmacro error! [s]
+        `(throw (RuntimeException. ~(with-meta s `{:tag java.lang.String}))))
 
-#+cljs (defn error! [& format-args]
-         (throw (js/Error (apply format format-args))))
+#+cljs (defn error! [s]
+         (throw (js/Error s)))
 
 (defn safe-get
   "Like get but throw an exception if not found"
   [m k]
   (if-let [pair (find m k)]
     (val pair)
-    (error! "Key %s not found in %s" k m)))
+    (error! (format "Key %s not found in %s" k m))))
 
 (defn value-name
   "Provide a descriptive short name for a value."


### PR DESCRIPTION
Fixes #12:
- Schema validation errors on function inputs come directly from the fn, not five layers deep in the stack
- s/defn generates named classes like defn
- Line numbers from error! come from the calling file, not from error! itself.
