### PR TITLE
Update docs on text fixture to reflect fn name

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ This documentation is probably the most important benefit of Schema, which is wh
 After documentation, the next-most important benefit is validation.  Thus far, we've found two key use cases for validation.  First, you can globally turn on function validation within a given test namespace by adding this line:
 
 ```clojure
-(use-fixtures :once schema.test/validate-schemata)
+(use-fixtures :once schema.test/validate-schemas)
 ```
 
 As long as your tests cover all call boundaries, this means you will should catch any 'type-like' bugs in your code at test time. 

--- a/src/cljx/schema/test.cljx
+++ b/src/cljx/schema/test.cljx
@@ -5,7 +5,7 @@
 
 (defn validate-schemas
   "A fixture for tests: put
-   (use-fixtures :once schema.test/validate-schemata)
+   (use-fixtures :once schema.test/validate-schemas)
    in your test file to turn on schema validation globally during all test executions."
   [fn-test]
   (s/with-fn-validation (fn-test)))


### PR DESCRIPTION
The docs don't currently match the fn name (`validate-schemata` vs. `validate-schemas`). Wikipedia says both are grammatically correct, but I don't really have a preference, just matching them up.
