### PR TITLE
fixes assert-iae, format now called properly and w/cljs friendly version

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -15,7 +15,7 @@
   "Like assert, but throws an IllegalArgumentException and takes args to format"
   [form & format-args]
   `(when-not ~form
-     (utils/error! (apply format ~format-args))))
+     (utils/error! (utils/format* ~@format-args))))
 
 (defmacro validation-error [schema value expectation & [fail-explanation]]
   `(utils/->ValidationError ~schema ~value (delay ~expectation) ~fail-explanation))


### PR DESCRIPTION
The macro was expanding out to (format ("foo")) before causing the String to be treated as a Fn.  So any call to `assert-iae` was resulting in a different error when the assertion failed.

I started writing a test for the macro to prevent against regressions in [this commit](https://github.com/bmabey/schema/commit/7b50d38777fd61c409c9d6bf92ea4c35a29548a3).  I was getting false-negatives on cljs so I didn't include it in the PR.
