### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,20 @@ As long as your tests cover all call boundaries, this means you will should catc
 
 Second, we manually call `s/validate` to check any data we read and write over the wire or to persistent storage, ensuring that we catch and debug bad data before it strays too far from its source.
 
-Longer-term, we have lots more in store for Schema.  Just a few of the crazy ideas we have brewing are:
+Finally, you can turn on, by default, validation for a given function (without the need for `with-fn-validation`):
+
+```
+(s/defn ^:always-validate stamped-names ...)
+```
+
+Thus, each time you invoke `stamped-names`, Schema will perform validation.
+
+## For the Future
+
+Longer-term, we have lots more in store for Schema. Just a few of the crazy ideas we have brewing are:
  - Automatically generate API client libraries based on API schemas
  - Automatically generate test data from schemas
  - Compile to `core.typed` annotations for more typey goodness, if that's your thing
-
 
 ## More examples
 


### PR DESCRIPTION
It wasn't immediately clear to me that I'd need to use `with-fn-validation`. In my case, I wanted to _always_ use validation, and I found the meta attribute on Primatic's Google group...
