### PR TITLE
Forcibly disable potemkin for CLJS

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -356,7 +356,7 @@
        (when ~extra-validator-fn?
          (assert-c! (fn? ~extra-validator-fn?) "Extra-validator-fn? not a fn: %s"
                     (class ~extra-validator-fn?)))
-       (~(if @*use-potemkin*
+       (~(if (and @*use-potemkin* (not (compiling-cljs?)))
            `potemkin/defrecord+
            `clojure.core/defrecord)
         ~name ~field-schema ~@more-args)


### PR DESCRIPTION
Before emitting potemkin/defrecord+, ensure that we aren't compiling for
ClojureScript. This may not be the ideal location for this check, but appears to
fix the problems described in Prismatic/schema#34
