### PR TITLE
Use `ifn?` to check if form can be used as predicate.

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -294,7 +294,7 @@
    Optional pred-name can be passed for nicer validation errors."
   ([p?] (pred p? p?))
   ([p? pred-name]
-     (when-not (fn? p?)
+     (when-not (ifn? p?)
        (macros/error! (utils/format* "Not a function: %s" p?)))
      (Predicate. p? pred-name)))
 


### PR DESCRIPTION
Objects created with `fn`, as well as data structures that can be used
as a function (eg: sets, maps) implement IFn. Using `ifn?` instead of
`fn?` allows us to use sets and maps as predicates.
