### PR TITLE
Make the Either schema validation error easier to understand.

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -428,7 +428,7 @@
           (if-not sub-walkers
             (macros/validation-error
              this x
-             (list 'either? (list 'check '% (utils/value-name x)) (map explain schemas)))
+             (list 'some (list 'check '% (utils/value-name x)) 'schemas))
             (let [res ((first sub-walkers) x)]
               (if-not (utils/error? res)
                 res


### PR DESCRIPTION
I've made some modifications to the Either schema to make it easier to decipher errors. I've changed the symbol in validation error for Either from every? to either?, and I've added the explanation of schemas to validation error for Either.
