### PR TITLE
Fix ns warning: remove is= use

### DIFF
--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -8,7 +8,7 @@
     - (invalid-call! s x) asserts that calling the function throws an error."
   #+clj (:use clojure.test [schema.test-macros :only [valid! invalid! invalid-call!]])
   #+cljs (:use-macros
-          [cemerick.cljs.test :only [is is= deftest testing]]
+          [cemerick.cljs.test :only [is deftest testing]]
           [schema.test-macros :only [valid! invalid! invalid-call!]])
   #+cljs (:require-macros
           [schema.macros :as sm])


### PR DESCRIPTION
Trivial, but I noticed the following warning when compiling cljs:

```
WARNING: No such namespace:  at line 1 target/generated/test/cljs/schema/core_test.cljs
```

Pretty unclear, but compiling with latest clojurescript gives gives a better
warning:

```
WARNING: Referred macro cemerick.cljs.test/is= does not exist at line 1 target/generated/test/cljs/schema/core_test.cljs
```

`is=` isn't used and removing it from `:use-macros` fixes the warning.
