### PR TITLE
Update JSON coercer to safely coerce doubles

### DIFF
--- a/src/cljx/schema/coerce.cljx
+++ b/src/cljx/schema/coerce.cljx
@@ -88,7 +88,7 @@
                        #+clj {clojure.lang.Keyword string->keyword
                               s/Int safe-long-cast
                               Long safe-long-cast
-                              Double double
+                              Double (safe double)
                               Boolean string->boolean})]
   (defn json-coercion-matcher
     "A matcher that coerces keywords and keyword enums from strings, and longs and doubles

--- a/test/cljx/schema/coerce_test.cljx
+++ b/test/cljx/schema/coerce_test.cljx
@@ -52,7 +52,9 @@
             (is (= res (coercer res)))
             (is (= {:jb true} (coercer {:jb "TRUE"})))
             (is (= {:jb false} (coercer {:jb "Yes"})))
-            (is (= #{:l :jk} (err-ks (coercer {:l 1.2 :jk 1.0})))))))
+            (is (= #{:l :jk} (err-ks (coercer {:l 1.2 :jk 1.0}))))
+            (is (= #{:d} (err-ks (coercer {:d nil}))))
+            (is (= #{:d} (err-ks (coercer {:d "1.0"})))))))
 
 (deftest string-coercer-test
   (let [coercer (coerce/coercer Generic coerce/string-coercion-matcher)]


### PR DESCRIPTION
Use (safe double) for coercion, so the original value will be preserved and validated when coercion fails.
