### PR TITLE
explain on bytes (and other array functions) results in an unreadable form

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -198,13 +198,18 @@
 
 #+clj
 (do
-  (defmacro extend-primitive [cast-sym class-sym]
-    `(extend-protocol Schema
-       ~cast-sym
-       (walker [this#]
-         (subschema-walker ~class-sym))
-       (explain [this#]
-         (explain ~class-sym))))
+  (defmacro extend-primitive
+    ([cast-sym class-sym expl-sym]
+       `(extend-protocol Schema
+          ~cast-sym
+          (walker [this#]
+            (subschema-walker ~class-sym))
+          (explain [this#]
+            ~(if expl-sym
+               (list 'quote expl-sym)
+               `(explain ~class-sym)))))
+    ([cast-sym class-sym]
+       `(extend-primitive ~cast-sym ~class-sym nil)))
 
   (extend-primitive clojure.core$double Double)
   (extend-primitive clojure.core$float Float)
@@ -215,14 +220,14 @@
   (extend-primitive clojure.core$byte Byte)
   (extend-primitive clojure.core$boolean Boolean)
 
-  (extend-primitive clojure.core$doubles (Class/forName "[D"))
-  (extend-primitive clojure.core$floats (Class/forName "[F"))
-  (extend-primitive clojure.core$longs (Class/forName "[J"))
-  (extend-primitive clojure.core$ints (Class/forName "[I"))
-  (extend-primitive clojure.core$shorts (Class/forName "[S"))
-  (extend-primitive clojure.core$chars (Class/forName "[C"))
-  (extend-primitive clojure.core$bytes (Class/forName "[B"))
-  (extend-primitive clojure.core$booleans (Class/forName "[Z")))
+  (extend-primitive clojure.core$doubles (Class/forName "[D") doubles)
+  (extend-primitive clojure.core$floats (Class/forName "[F") floats)
+  (extend-primitive clojure.core$longs (Class/forName "[J") longs)
+  (extend-primitive clojure.core$ints (Class/forName "[I") ints)
+  (extend-primitive clojure.core$shorts (Class/forName "[S") shorts)
+  (extend-primitive clojure.core$chars (Class/forName "[C") chars)
+  (extend-primitive clojure.core$bytes (Class/forName "[B") bytes)
+  (extend-primitive clojure.core$booleans (Class/forName "[Z") booleans))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Cross-platform Schema leaves


### PR DESCRIPTION
Calling `explain` on a schema with `bytes` results in an unreadable form.

``` clj
(explain bytes)
    => [B
```

I'm not fully aware of all the implications, but having `explain` return `bytes` in this situation seems preferable to me (and I think this would be a straightforward modification to `extend-primitive` to implement).  The other array extensions are similar.
