### PR TITLE
Prevent analyzer warning by using non-js base-type

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -174,7 +174,7 @@
 
 (extend-protocol Schema
   #+clj Class
-  #+cljs js/Function
+  #+cljs function
   (walker [this]
     (let [class-walker (if-let [more-schema (utils/class-schema this)]
                          ;; do extra validation for records and such


### PR DESCRIPTION
The CLJS analyzer warns against using any of the symbols in js-base-type map
https://github.com/clojure/clojurescript/blob/a10080d7743e480f689d50e2558415e6b63e7632/src/clj/cljs/core.clj#L605-L621
