### PR TITLE
Add named-either schema.

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -440,6 +440,33 @@
   [& schemas]
   (Either. schemas))
 
+(defrecord NamedEither [schemas-by-name]
+  Schema
+  (walker [this]
+    (let [sub-walkers (mapv subschema-walker (vals schemas-by-name))]
+      (fn [x]
+        (loop [sub-walkers (seq sub-walkers)]
+          (if (empty? sub-walkers)
+            (macros/validation-error
+              this, x
+              (list
+                'some
+                (list 'check '% (utils/value-name x))
+                (mapv symbol (keys schemas-by-name))))
+            (let [result ((first sub-walkers) x)]
+              (if-not (utils/error? result)
+                result
+                (recur (next sub-walkers)))))))))
+  (explain [this] (cons 'either (map explain (vals schemas-by-name)))))
+
+(defn named-either
+  "A value that must satisfy at least one of the named schema in schemas."
+  [name schema & names-and-schemas]
+  (let [all-names-and-schemas (concat [name schema] names-and-schemas)]
+    (NamedEither. (->> all-names-and-schemas
+                    (partition 2)
+                    (map vec)
+                    (into {})))))
 
 ;;; both (satisfies this schema and that one)
 

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -202,6 +202,17 @@
     (is (= '(either {:a Int} Int) (s/explain (s/either {:a s/Int} s/Int))))
     (is (s/explain schema))))
 
+(deftest named-either-test
+  (let [schema (s/named-either
+                 "Key" s/Keyword
+                 "Path" [s/Keyword])]
+    (valid! schema :foo)
+    (valid! schema [:foo :bar :baz])
+    (invalid! schema 1 "(not (some (check % 1) [Key Path]))")
+    (invalid! schema [:foo 2] "(not (some (check % [:foo 2]) [Key Path]))")
+    (is (= '(either Keyword [Keyword]) (s/explain schema)))
+    (is (s/explain schema))))
+
 (deftest both-test
   (let [schema (s/both
                 (s/pred (fn equal-keys? [m] (every? (fn [[k v]] (= k v)) m)) 'equal-keys?)


### PR DESCRIPTION
A named-either schema is like an either schema, except that the schemas have names. The names appear in the schema's validation failure messages, to make it easier to understand what the failing value should be.

We are using schema validation failures as part of our response to users when they submit a malformed object. The either schema's failure message, `(not (some (check % value) schemas))`, doesn't have any information about what the schemas actually are, so it was not useful for us. The named-either schema lets us replace `schemas` with the schema names so that the user has some idea of what went wrong and what they should be trying to match.
