### PR TITLE
use the schema's fully-qualified symbol in defschema's naming

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -303,7 +303,9 @@
   ([name form]
      `(defschema ~name "" ~form))
   ([name docstring form]
-     `(def ~name ~docstring (schema.core/schema-with-name ~form '~name))))
+     (let [fully-qualified (-> (ns-name *ns*) (str "/" name) symbol)]
+       `(def ~name ~docstring (schema.core/schema-with-name ~form '~fully-qualified)))))
+
 
 ;;; The clojure version is a function in schema.core, this must be here for cljs because
 ;;; satisfies? is a macro that must have access to the protocol at compile-time.


### PR DESCRIPTION
This allows defschema to be used in conjunction with plumbing eager-compile. 
See [this closed ticket](https://github.com/Prismatic/schema/pull/104) on the problems caused when no qualificiation of the
symbol is done.

I tried using syntax quote to do the qualifying for me since that is it's job,
but I didn't have any luck using it with conjuntion with ~ and ' in this particular
case.  I'd love to see an alternative approach that uses syntax-quote if you know
how to do it. :)  

As is this appraoch works fine and solves the issue as outlined here:

https://github.com/Prismatic/plumbing/issues/38
