### PR TITLE
added defmulti support (default hints for defmethod)

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -898,7 +898,7 @@
 ;; In ClojureScript, you have to use them from clj schema.macros
 #+clj
 (do
-  (doseq [s ['fn 'defn 'letfn 'defrecord]] (ns-unmap *ns* s))
+  (doseq [s ['fn 'defn 'letfn 'defrecord 'defmulti 'defmethod]] (ns-unmap *ns* s))
   (potemkin/import-vars
    macros/defrecord
    macros/fn
@@ -906,7 +906,10 @@
    macros/letfn
    macros/with-fn-validation
    macros/without-fn-validation
-   macros/def)
+   macros/def
+   macros/defmulti
+   macros/defmethod
+   )
   (reset! macros/*use-potemkin* true) ;; Use potemkin for s/defrecord by default.
   (set! *warn-on-reflection* false))
 

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -1012,45 +1012,95 @@
   #+clj (is (thrown? Exception (sm/def ^s/Int v 1.0))))
 
 
-;; defmethod
 
-(defmulti m #(:k (first %&)))
+;; defmethod & defmulti 
 
 (deftest defmethod-unannotated-test
-  (sm/defmethod m :v [m x y] (+ x y))
+  (def m nil)
+  (defmulti m #(:k (first %&)))
+  (sm/defmethod schema.core-test/m :v [m x y] (+ x y))
   (is (= 3 (m {:k :v} 1 2))))
 
 (deftest defmethod-input-annotated
+  (def m nil)
+  (defmulti m #(:k (first %&)))
   (sm/defmethod m :v [m :- {:k s/Keyword} x :- s/Num y :- s/Num] (+ x y))
   (is (= 3
          (sm/with-fn-validation (m {:k :v} 1 2)))))
 
 (deftest defmethod-output-annotated
+  (def m nil)
+  (defmulti m #(:k (first %&)))
   (sm/defmethod m :v :- s/Num [m x y] (+ x y))
   (is (= 3
          (sm/with-fn-validation (m {:k :v} 1 2)))))
 
 (deftest defmethod-all-annotated
+  (def m nil)
+  (defmulti m #(:k (first %&)))
   (sm/defmethod m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] (+ x y))
   (is (= 3
          (sm/with-fn-validation (m {:k :v} 1 2)))))
 
 (deftest defmethod-input-error-test
+  (def m nil)
+  (defmulti m #(:k (first %&)))
   (sm/defmethod m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] (+ x y))
   (is (thrown? #+clj RuntimeException #+cljs js/Error
                (sm/with-fn-validation
                  (sm/with-fn-validation (m {:k :v} 1 "2"))))))
 
 (deftest defmethod-output-error-test
+  (def m nil)
+  (defmulti m #(:k (first %&)))
   (sm/defmethod m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] "wrong")
   (is (thrown? #+clj RuntimeException #+cljs js/Error
-               (sm/with-fn-validation
-                 (sm/with-fn-validation (m {:k :v} 1 2))))))
+               (sm/with-fn-validation (m {:k :v} 1 2)))))
 
 (deftest defmethod-metadata-test
+  (def m nil)
+  (defmulti m #(:k (first %&)))
   (sm/defmethod ^:always-validate m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] "wrong")
   (is (thrown? #+clj RuntimeException #+cljs js/Error
               (m {:k :v} 1 2))))
+
+(deftest defmulti-unannotated-test
+  (def m nil)
+  (sm/defmulti m "not annotated defmulti" :k :default :d)
+  (defmethod m :d [v] 1) ; must work exactly as clojure.core/defmethod
+  (defmethod m :v [v] 2)
+  (is (= 1 (m :any)))
+  (is (= 2 (m {:k :v})))
+  )
+
+(deftest defmulti-input-annotated
+  (def m nil)
+  (sm/defmulti m (fn [k & _] k) [k :- s/Keyword x :- s/Num y :- s/Num] :default :d)
+  (sm/defmethod m :v [k x y] (list x y))                         ; will apply defmulti hints
+  (sm/defmethod m :d [k :- s/Keyword x :- s/Str y :- s/Num] :ok) ; defmulti hints will be ignored.
+  (is (thrown? #+clj RuntimeException #+cljs js/Error
+           (sm/with-fn-validation (m :v "erroneus-arg" 4))))
+  (is (= :ok (sm/with-fn-validation (m :z "now-ok-arg" 6))))
+  )
+
+(deftest defmulti-output-annotated
+  (def m nil)
+  (sm/defmulti m (fn [k & _] k) :- s/Str :default :d)
+  (sm/defmethod m :v [k x y] 8)
+  (sm/defmethod m :d :- s/Num [k x y] 8)
+  (is (thrown? #+clj RuntimeException #+cljs js/Error
+               (sm/with-fn-validation (m :v 1 4))))
+  (is (= 8 (sm/with-fn-validation (m :z 1 4))))
+  )
+
+(deftest defmulti-metadata-test
+  (def m nil)
+  (sm/defmulti ^:always-validate m (fn [k & _] k) [k :- s/Keyword x :- s/Num y :- s/Num] :default :d)
+  (sm/defmethod m :v [k x y] (list x y))
+  (is (thrown? #+clj RuntimeException #+cljs js/Error
+               (m :v "erroneus-arg" 4)))
+  )
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Composite Schemas (test a few combinations of above)


### PR DESCRIPTION
Added `schema.macros/defmulti`, as a way to set default schema input/output hints to `schema.macros/defmethod` subsequent invocations
