### PR TITLE
Make schema.core/recursive work with any IDeref

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -529,7 +529,9 @@
       (list 'recursive
             (if (var? derefable)
               (list 'var (var-name derefable))
-              '(derefable)))))
+              (format "%s@%x"
+                      (.getName (class derefable))
+                      (System/identityHashCode derefable))))))
 
   (defn recursive
     "Support for (mutually) recursive schemas by passing a var that points to a schema,

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -289,8 +289,11 @@
         (valid! schema {})
         (valid! schema {:x {:x {:x {}}}})
         (invalid! schema {:x {:x {:y {}}}})
-        (is (= '{(optional-key :x) (recursive (derefable))}
-               (s/explain schema))))
+        (let [explanation (first (s/explain schema))]
+          (is (= '(optional-key :x) (key explanation)))
+          (is (= 'recursive (first (val explanation))))
+          (is (re-matches #"clojure\.core\$promise.*"
+                          (second (val explanation))))))
 
       (is (= '{:black {(optional-key :red) (recursive (var schema.core-test/BlackNode))}}
              (s/explain BlackNode)))))


### PR DESCRIPTION
This patch extends the behaviour of `schema.core/{Recursive,recursive}` enabling them to work with any object implementing `clojure.core.IDeref`.

Thanks to this change it is not required to introduce a var to define a recursive schema. This in turn allows to
- avoid defining a var per each recursive schema, and
- create recursive schemas by using let bindings exclusively without
  any details leaking into the namespace level bindings.

Now recursive schemas can be built on top of promises, atoms or custom reifications of `IDeref`.

The existing behaviour remains intact.

What do you think about it?
