### PR TITLE
Conditional compilation actually based on the target, not just presence of cljs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.4
+ * Fixed an issue that could cause ClojureScript compilation to fail
+ * Generalize `s/recursive` to work on artibrary refs
+ * Add `s/Symbol` as a cross-platfor primitive
+
 ## 0.2.3
  * Improved explains for primitives & primitive arrays
  * More robust double coercions

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Clojure(Script) library for declarative data description and validation. 
 
-Leiningen dependency (Clojars): `[prismatic/schema "0.2.2"]`. [Latest codox API docs](http://prismatic.github.io/schema).
+Leiningen dependency (Clojars): `[prismatic/schema "0.2.4"]`. [Latest codox API docs](http://prismatic.github.io/schema).
 
 **This is an alpha release. The API and organizational structure are
 subject to change. Comments and contributions are much appreciated.**

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -26,8 +26,8 @@
   (def AssertionError js/Error)
   (def Throwable js/Error))
 
-(deftest compiling-cljs?-test
-  (is (= #+cljs true #+clj false (sm/compiling-cljs-now?))))
+(deftest if-cljs-test
+  (is (= #+cljs true #+clj false (sm/if-cljs true false))))
 
 (deftest try-catchall-test
   (let [a (atom 0)]


### PR DESCRIPTION
Support for a fix to https://github.com/Prismatic/plumbing/issues/42

Not sure why this works in our projects but not in the example given there, but it seems that we were sometimes generating Clojurescript when macroexpanding into Clojure (possibly depending on compilation order).  This fixes things using the strategy described here:

https://groups.google.com/d/msg/clojurescript/iBY5HaQda4A/w1lAQi9_AwsJ
