### PR TITLE
preserves the record type when validating a map-schema

### DIFF
--- a/src/cljx/schema/utils.cljx
+++ b/src/cljx/schema/utils.cljx
@@ -1,5 +1,6 @@
 (ns schema.utils
   "Private utilities used in schema implementation."
+  #+clj (:refer-clojure :exclude [record?])
   #+cljs (:require goog.string.format [goog.string :as gstring]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -49,6 +50,10 @@
                   (.put m x res)
                   res))))
   #+cljs (memoize f))
+
+(defn record? [x]
+  #+clj (instance? clojure.lang.IRecord x)
+  #+cljs (satisfies? IRecord x))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -353,6 +353,20 @@
   (is (thrown? Exception (s/checker {:foo s/Str (s/optional-key :foo) s/Str})))
   (is (thrown? Exception (s/checker {(s/required-key "A") s/Str (s/optional-key "A") s/Str}))))
 
+(defprotocol SomeProtocol
+  (stuff [this]))
+
+(defrecord SomeRecord [x y z]
+  SomeProtocol
+  (stuff [_] x))
+
+(deftest preserve-type-in-map-schema-check
+  (let [field-subset {:x s/Keyword :y s/Num s/Keyword s/Any}
+        protocol-schema #+clj (s/protocol SomeProtocol) #+cljs (sm/protocol SomeProtocol)
+        schema (s/both field-subset protocol-schema)]
+    (valid! schema (->SomeRecord :foo 42 "extra"))
+    (invalid! schema {:x :foo :y 42})))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Handle Struct
 


### PR DESCRIPTION
This issue was brought up on #68.

Perseving the type is required in some cases when other schemas, in a 
composite schema,  are relying on the type information being present
(e.g. s/protocol). See the new test case for an example of this.

I should point out that the added `record?` util fn is redundant in
Clojure 1.6.x and so the following error will be printed:

```
WARNING: record? already refers to: #'clojure.core/record? in namespace: schema.utils, being replaced by: #'schema.utils/record?
```

`record?` hasn't been added to ClojureScript yet.

Before merging this in could you give me some guidance on how I can use
a cljx project as a lein checkout?  I wanted to test this locally in my
own project but couldn't figure out the best way to do that.  Even when I do
`lein install` I get the following compile error:

```
No such var: schema-macros/compiling-cljs?, compiling:(plumbing/fnk/impl.clj:352:19)
```
