### PR TITLE
Name with attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.5 
+ * Add `normalized-defn-args` helper fn for defining `s/defn`-like macros.
+
 ## 0.2.4
  * Fixed an issue that could cause ClojureScript compilation to fail
  * Generalize `s/recursive` to work on artibrary refs

--- a/test/clj/schema/macros_test.clj
+++ b/test/clj/schema/macros_test.clj
@@ -1,0 +1,20 @@
+(ns schema.macros-test
+  (:use clojure.test)
+  (:require
+   [schema.core :as s]
+   [schema.macros :as macros]))
+
+(deftest normalized-defn-args-test
+  (doseq [explicit-meta [{} {:a -1 :c 3}]
+          [schema-attrs schema-forms] {{:schema `s/Any} []
+                                       {:schema 'Long :tag 'Long} [:- 'Long]}
+          [doc-attrs doc-forms] {{} []
+                                 {:doc "docstring"} ["docstring"]}
+          [attr-map attr-forms] {{} {}
+                                 {:a 1 :b 2} [{:a 1 :b 2}]}]
+    (let [simple-body ['[x] `(+ 1 1)]
+          full-args (concat [(with-meta 'abc explicit-meta)] schema-forms doc-forms attr-forms simple-body)
+          [name & more] (macros/normalized-defn-args {} full-args)]
+      (testing (vec full-args)
+        (is (= (concat ['abc (merge explicit-meta schema-attrs doc-attrs attr-map) simple-body])
+               (concat [name (meta name) more])))))))


### PR DESCRIPTION
Addresses #54 , adding a helper fn for defining `defn`-style macros that use schema.  This can remove some boilerplate in plumbing, and in `defmulti` support (see #111 )
