### PR TITLE
Remove uses of assert-c! and simplify docstrings now that conditional expansion works properly

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -59,7 +59,7 @@
   `(when-not ~form
      (error! (utils/format* ~@format-args))))
 
-(defmacro assert-c!
+(defmacro ^:deprecated assert-c!
   "DEPRECATED.  (No longer necessary now that macroexpansion properly detects context).
    Like assert! but throws a RuntimeException and takes args to format.  Only
    for use during compilation."


### PR DESCRIPTION
Previously, we had to separate platform-dependent code that was called during macroexpansion from code called on the client, since the old `compiling-cljs` couldn't tell the difference between Clojure compilation and ClojureScript generation.  The new `if-cljs` can tell the difference, so error handling can be simplified.
