### PR TITLE
Bugfix for defrecord - removing dead code at compile-time.

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -380,8 +380,8 @@
                                     (keys ~extra-key-schema?)))]
          (assert! (not bad-keys#) "extra-key-schema? can not contain required keys: %s"
                   (vec bad-keys#)))
-       (when ~extra-validator-fn?
-         (assert! (fn? ~extra-validator-fn?) "Extra-validator-fn? not a fn: %s"
+       ~(when extra-validator-fn?
+         `(assert! (fn? ~extra-validator-fn?) "Extra-validator-fn? not a fn: %s"
                   (class ~extra-validator-fn?)))
        (~(if (and @*use-potemkin* (not (cljs-env? &env)))
            `potemkin/defrecord+


### PR DESCRIPTION
When using defrecord with schema 0.2.5+ & ClojureScript versions
_after_ 2234, this is a common error:

WARNING: JSC_UNREACHABLE_CODE. unreachable code at .... line 1027 : 0

The reason seems to be that the newer Closure compiler has better
dead-code checking.  Using defrecord without suppling an
extra-validator-fn? compiles down to something like:

  if (null) { ...assert it's a function...}

...which the Closure compiler rightly warns is unreachable code.

This commit just changes the macro so that if we know there's no
extra-validator-fn? at compile time, we don't emit code to check it at
runtime.
