### PR TITLE
add default type key on ExInfo errors to distinguish them from other ExInfo

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -40,9 +40,10 @@
        (throw (js/Error. ~s))
        (throw (RuntimeException. ~(with-meta s `{:tag java.lang.String})))))
   ([s m]
-     `(if-cljs
-       (throw (ex-info ~s ~m))
-       (throw (clojure.lang.ExceptionInfo. ~(with-meta s `{:tag java.lang.String}) ~m)))))
+     (let [m (merge {:type :schema.core/error} m)]
+       `(if-cljs
+         (throw (ex-info ~s ~m))
+         (throw (clojure.lang.ExceptionInfo. ~(with-meta s `{:tag java.lang.String}) ~m))))))
 
 (defmacro safe-get
   "Like get but throw an exception if not found.  A macro just to work around cljx function


### PR DESCRIPTION
Right now it adds a bit of boilerplate to deal with validation error that pop via ExInfo in an app that makes heavy use of them already. Adding a simple :type key allows to distinguish them from others efficiently.

This patch adds {:type :schema/error ..} on the ExInfo map created via the error! macro.
It's possible to overwrite this value via error! if a :type key is supplied to the map arg.
This makes possible to pattern match against these errors with libraries such as [catch-data](https://github.com/gfredericks/catch-data) or [slingshot](https://github.com/scgilardi/slingshot)
