### PR TITLE
Make find-extra-keys-schema public

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -658,7 +658,7 @@
 
 ;;; Implementation helper functions
 
-(defn- find-extra-keys-schema [map-schema]
+(defn find-extra-keys-schema [map-schema]
   (let [key-schemata (remove specific-key? (keys map-schema))]
     (macros/assert! (< (count key-schemata) 2)
                     "More than one non-optional/required key schemata: %s"


### PR DESCRIPTION
For coercions on map-schemas `find-extra-keys-schema` can be useful, so this patch makes it public.

As proposed by @w01fe in https://groups.google.com/forum/#!topic/prismatic-plumbing/SaOBraHzoHE
