### PR TITLE
Make parse-sequence-schema public

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -784,6 +784,10 @@
      (One. schema true name)))
 
 (defn parse-sequence-schema [s]
+  "Parses and validates a sequence schema, returning a vector in the form
+  [singles multi] where singles is a sequence of 'one' and 'optional' schemas
+  and multi is the rest-schema (which may be nil). A valid sequence schema is
+  a vector in the form [one* optional* rest-schema?]."
   (let [[required more] (split-with #(and (instance? One %) (not (:optional? %))) s)
         [optional more] (split-with #(and (instance? One %) (:optional? %)) more)]
     (macros/assert!


### PR DESCRIPTION
Makes it possible to reuse the parsing and validation of a sequence schema, which is useful when using sequence schema as a building block for other schemas: it's used in function schema, and I'm using a sequence schema as a building block for my combinations schema.
