### PR TITLE
Move macros to core and deprecate potemkin dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.2.7
+ * **BREAKING** increase minimum clojurescript version 2120 to support :include-macros
  * **Deprecate** direct use of `schema.macros` in client code -- prefer canonical versions in `schema.core`
    in both Clojure and ClojureScript, using `:include-macros true` in cljs.
  * **Deprecate** old `^{:s schema}` syntax for providing schemas.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ A Schema is a Clojure(Script) data structure describing a data shape, which can 
 
 ```clojure
 (ns schema-examples
-  (:require [schema.core :as s]))
+  (:require [schema.core :as s 
+             :include-macros true ;; cljs only
+             ]))
 
 (def Data
   "A schema for a nested data type"
@@ -127,14 +129,11 @@ Clojure's type hints make great documentation, but they fall short for complex t
 Schema provides macros `defrecord`, `defn`, and `fn` that help bridge this gap, by allowing arbitrary schemas as type hints on fields, arguments, and return values.  This is a graceful extension of Clojure's type hinting system, because every type hint is a valid Schema, and Schemas that represent valid type hints are automatically passed through to Clojure.
 
 ```clojure
-;; only necessary for cljs, macros are imported to schema.core in clj
-(require '[schema.macros :as sm])
-
-(sm/defrecord StampedNames
+(s/defrecord StampedNames
   [date :- Long
    names :- [s/Str]])
 
-(sm/defn stamped-names :- StampedNames
+(s/defn stamped-names :- StampedNames
   [names :- [s/Str]]
   (StampedNames. (str (System/currentTimeMillis)) names))
 ```
@@ -166,7 +165,7 @@ As you can see, these type hints are precise, easy to read, and shorter than the
 
 We've already seen how we can build up Schemas via composition, attach them to functions, and use them to validate data. What does this look like in practice?
 
-First, we ensure that all data types that will be shared across namespaces (or heavily used within namespaces) have Schemas, either by `def`ing them or using `sm/defrecord`.  This allows us to compactly and precisely refer to this data type in more complex data types, or when documenting function arguments and return values.
+First, we ensure that all data types that will be shared across namespaces (or heavily used within namespaces) have Schemas, either by `def`ing them or using `s/defrecord`.  This allows us to compactly and precisely refer to this data type in more complex data types, or when documenting function arguments and return values.
 
 This documentation is probably the most important benefit of Schema, which is why we've optimized Schemas for easy readability and reuse -- and sometimes, this is all you need. Schemas are purely descriptive, not prescriptive, so unlike a type system they should never get in your way, or constrain the types of functions you can write.
 
@@ -319,12 +318,6 @@ Here, `json-coercion-matcher` provides some useful defaults for coercing from JS
 There's nothing special about `json-coercion-matcher` though; it's just as easy to [make your own schema-specific transformations](https://github.com/Prismatic/schema/wiki/Writing-Custom-Transformations) to do even more.
 
 For more details, see [this blog post](http://blog.getprismatic.com/schema-0-2-0-back-with-clojurescript-data-coercion/).
-
-## Compilation
-
-Currently the way schema.core imports schema.macros breaks with AOT compilation. This was done for ClojureScript's sake but it is no longer necessary and we are planning to collapse them back in a future major release.
-
-In the mean time, if your project is being compiled AOT and you are using the macros (defn, defrecord etc) you should explicitly require schema.macros as described above.
 
 ## For the Future
 

--- a/project.clj
+++ b/project.clj
@@ -7,13 +7,12 @@
   :dependencies [[potemkin "0.3.2"]]
 
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]
-                                  [org.clojure/clojurescript "0.0-2030"]
+                                  [org.clojure/clojurescript "0.0-2120"]
                                   [com.keminglabs/cljx "0.3.1"]]
                    :plugins [[com.keminglabs/cljx "0.3.1"]
                              [codox "0.8.8"]
-                             [lein-cljsbuild "0.3.2"]
-                             [com.cemerick/austin "0.1.3"]
-                             [com.cemerick/clojurescript.test "0.2.2"]]
+                             [lein-cljsbuild "1.0.2"]
+                             [com.cemerick/clojurescript.test "0.3.1"]]
                    :hooks [leiningen.cljsbuild]
                    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl
                                                      cljx.repl-middleware/wrap-cljx]}

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -487,5 +487,11 @@
   "DEPRECATED -- canonical version moved to schema.core"
   [multifn dispatch-val & fn-tail]
   `(if-cljs
-    (cljs.core/-add-method ~(with-meta multifn {:tag 'cljs.core/MultiFn}) ~dispatch-val (schema.macros/fn ~(with-meta (gensym) (meta multifn)) ~@fn-tail))
-    (. ~(with-meta multifn {:tag 'clojure.lang.MultiFn}) addMethod        ~dispatch-val (schema.macros/fn ~(with-meta (gensym) (meta multifn)) ~@fn-tail))))
+    (cljs.core/-add-method
+     ~(with-meta multifn {:tag 'cljs.core/MultiFn})
+     ~dispatch-val
+     (fn ~(with-meta (gensym) (meta multifn)) ~@fn-tail))
+    (. ~(with-meta multifn {:tag 'clojure.lang.MultiFn})
+       addMethod
+       ~dispatch-val
+       (fn ~(with-meta (gensym) (meta multifn)) ~@fn-tail))))

--- a/src/cljx/schema/coerce.cljx
+++ b/src/cljx/schema/coerce.cljx
@@ -4,7 +4,7 @@
    #+cljs [cljs.reader :as reader]
    #+clj [clojure.edn :as edn]
    #+clj [schema.macros :as macros]
-   [schema.core :as s]
+   [schema.core :as s :include-macros true]
    [schema.utils :as utils]
    [clojure.string :as str])
   #+cljs (:require-macros [schema.macros :as macros]))
@@ -14,16 +14,15 @@
 
 (def Schema
   "A Schema for Schemas"
-  #+clj (s/protocol s/Schema)
-  #+cljs (macros/protocol s/Schema))
+  (s/protocol s/Schema))
 
 (def CoercionMatcher
   "A function from schema to coercion function, or nil if no special coercion is needed.
    The returned function is applied to the corresponding data before validation (or walking/
    coercion of its sub-schemas, if applicable)"
-  (macros/=> (s/maybe (macros/=> s/Any s/Any)) Schema))
+  (s/=> (s/maybe (s/=> s/Any s/Any)) Schema))
 
-(macros/defn coercer
+(s/defn coercer
   "Produce a function that simultaneously coerces and validates a datum."
   [schema coercion-matcher :- CoercionMatcher]
   (s/start-walker
@@ -44,7 +43,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Coercion helpers
 
-(macros/defn first-matcher :- CoercionMatcher
+(s/defn first-matcher :- CoercionMatcher
   "A matcher that takes the first match from matchers."
   [matchers :- [CoercionMatcher]]
   (fn [schema] (first (keep #(% schema) matchers))))

--- a/src/cljx/schema/test.cljx
+++ b/src/cljx/schema/test.cljx
@@ -1,7 +1,7 @@
 (ns schema.test
   "Utilities for testing with schemas"
-  #+clj (:require [schema.core :as s] clojure.test)
-  #+cljs (:require-macros [schema.macros :as s]))
+  (:require [schema.core :as s :include-macros true]
+            #+clj clojure.test))
 
 (defn validate-schemas
   "A fixture for tests: put

--- a/test/clj/schema/test_macros.clj
+++ b/test/clj/schema/test_macros.clj
@@ -2,7 +2,7 @@
   "Macros to help cross-language testing of schemas."
   (:require
    clojure.test
-   [schema.macros :as sm]))
+   [schema.core :as s :include-macros true]))
 
 (defmacro valid!
   "Assert that x satisfies schema s, and the walked value is equal to the original."

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -10,13 +10,12 @@
   #+cljs (:use-macros
           [cemerick.cljs.test :only [is deftest testing]]
           [schema.test-macros :only [valid! invalid! invalid-call!]])
-  #+cljs (:require-macros
-          [schema.macros :as sm])
+  #+cljs (:require-macros [schema.macros :as macros])
   (:require
    clojure.data
    [schema.utils :as utils]
-   [schema.core :as s]
-   #+clj [schema.macros :as sm]
+   [schema.core :as s :include-macros true]
+   #+clj [schema.macros :as macros]
    #+cljs cemerick.cljs.test))
 
 #+cljs
@@ -26,14 +25,14 @@
   (def Throwable js/Error))
 
 (deftest if-cljs-test
-  (is (= #+cljs true #+clj false (sm/if-cljs true false))))
+  (is (= #+cljs true #+clj false (macros/if-cljs true false))))
 
 (deftest try-catchall-test
   (let [a (atom 0)]
-    (is (= 2 (sm/try-catchall (reset! a 1) (swap! a inc) (catch e (swap! a - 10)))))
+    (is (= 2 (macros/try-catchall (reset! a 1) (swap! a inc) (catch e (swap! a - 10)))))
     (is (= 2 @a)))
   (let [a (atom 0)]
-    (is (= -9 (sm/try-catchall (reset! a 1) (swap! a #(throw (sm/error! (str %)))) (catch e (swap! a - 10)))))
+    (is (= -9 (macros/try-catchall (reset! a 1) (swap! a #(throw (macros/error! (str %)))) (catch e (swap! a - 10)))))
     (is (= -9 @a))))
 
 (deftest validate-return-test
@@ -125,7 +124,7 @@
 (defrecord NonTestProtocolSatisfier [])
 
 (deftest protocol-test
-  (let [schema (sm/protocol ATestProtocol)]
+  (let [schema (s/protocol ATestProtocol)]
     (valid! schema (DirectTestProtocolSatisfier.))
     (valid! schema (IndirectTestProtocolSatisfier.))
     (invalid! schema (NonTestProtocolSatisfier.))
@@ -373,7 +372,7 @@
 
 (deftest preserve-type-in-map-schema-check
   (let [field-subset {:x s/Keyword :y s/Num s/Keyword s/Any}
-        protocol-schema #+clj (s/protocol SomeProtocol) #+cljs (sm/protocol SomeProtocol)
+        protocol-schema (s/protocol SomeProtocol)
         schema (s/both field-subset protocol-schema)]
     (valid! schema (->SomeRecord :foo 42 "extra"))
     (invalid! schema {:x :foo :y 42})))
@@ -533,20 +532,20 @@
 ;;; Function Schemas
 
 (deftest single-arity-fn-schema-test
-  (let [schema (sm/=> s/Keyword s/Int s/Int)]
+  (let [schema (s/=> s/Keyword s/Int s/Int)]
     (valid! schema (fn [x y] (keyword (str (+ x y)))))
     (valid! schema (fn [])) ;; we don't actually validate what the function does
     (valid! schema {})
     (is (= '(=> Keyword Int Int) (s/explain schema)))))
 
 (deftest single-arity-and-more-fn-schema-test
-  (let [schema (sm/=> s/Keyword s/Int s/Int & [s/Keyword])]
+  (let [schema (s/=> s/Keyword s/Int s/Int & [s/Keyword])]
     (valid! schema (fn [])) ;; we don't actually validate what the function does
     (valid! schema {})
     (is (= '(=> Keyword Int Int & [Keyword]) (s/explain schema)))))
 
 (deftest multi-arity-fn-schema-test
-  (let [schema (sm/=>* s/Keyword [s/Int] [s/Int & [s/Keyword]])]
+  (let [schema (s/=>* s/Keyword [s/Int] [s/Int & [s/Keyword]])]
     (valid! schema (fn [])) ;; we don't actually validate what the function does
     (valid! schema {})
     (is (= '(=>* Keyword [Int] [Int & [Keyword]]) (s/explain schema)))))
@@ -556,7 +555,7 @@
 ;;; Schematized defrecord
 
 (defmacro test-normalized-meta [symbol ex-schema desired-meta]
-  (let [normalized (schema.macros/normalized-metadata &env symbol ex-schema)]
+  (let [normalized (macros/normalized-metadata &env symbol ex-schema)]
     `(do (is (= '~symbol '~normalized))
          (is (= ~(select-keys desired-meta [:schema :tag])
                 ~(select-keys (meta normalized) [:schema :tag]))))))
@@ -575,9 +574,9 @@
     (testing "explicit" (test-normalized-meta ^Object foo String {:tag Object :schema String})))
 
   (defmacro test-meta-extraction [meta-form arrow-form]
-    (let [meta-ized (schema.macros/process-arrow-schematized-args {} arrow-form)]
+    (let [meta-ized (macros/process-arrow-schematized-args {} arrow-form)]
       `(do (is (= '~meta-form '~meta-ized))
-           (is (= ~(mapv #(select-keys (meta (schema.macros/normalized-metadata {} % nil)) [:schema :tag]) meta-form)
+           (is (= ~(mapv #(select-keys (meta (macros/normalized-metadata {} % nil)) [:schema :tag]) meta-form)
                   ~(mapv #(select-keys (meta %) [:schema :tag]) meta-ized))))))
 
   (deftest extract-arrow-schematized-args-test
@@ -592,22 +591,22 @@
 
 ;; exercies some different arities
 
-(sm/defrecord Bar
+(s/defrecord Bar
     [^s/Int foo ^s/Str bar]
   {(s/optional-key :baz) s/Keyword})
 
-(sm/defrecord Bar2
+(s/defrecord Bar2
     [^s/Int foo ^s/Str bar]
   {(s/optional-key :baz) s/Keyword}
   PProtocol
   (do-something [this] 2))
 
-(sm/defrecord Bar3
+(s/defrecord Bar3
     [^s/Int foo ^s/Str bar]
   PProtocol
   (do-something [this] 3))
 
-(sm/defrecord Bar4
+(s/defrecord Bar4
     [^{:s [s/Int]} foo ^{:s? {s/Str s/Str}} bar]
   PProtocol
   (do-something [this] 4))
@@ -639,7 +638,7 @@
   (invalid! Bar4 (Bar4. ["a"] {"test" "test"}))
   (is (= 4 (do-something (Bar4. 1 "test")))))
 
-(sm/defrecord BarNewStyle
+(s/defrecord BarNewStyle
     [foo :- s/Int
      bar :- s/Str
      zoo]
@@ -666,9 +665,9 @@
 
 (def LongOrString (s/either s/Int s/Str))
 
-#+clj (sm/defrecord Nested [^Bar4 b ^LongOrString c ^PProtocol p])
-#+clj (sm/defrecord NestedNew [b :- Bar4 c :- LongOrString p :- PProtocol])
-(sm/defrecord NestedExplicit [b :- Bar4 c :- LongOrString p :- (sm/protocol PProtocol)])
+#+clj (s/defrecord Nested [^Bar4 b ^LongOrString c ^PProtocol p])
+#+clj (s/defrecord NestedNew [b :- Bar4 c :- LongOrString p :- PProtocol])
+(s/defrecord NestedExplicit [b :- Bar4 c :- LongOrString p :- (s/protocol PProtocol)])
 
 (defn test-fancier-defrecord-schema [klass constructor]
   (let [bar1 (Bar. 1 "a")
@@ -676,7 +675,7 @@
     (is (= (utils/class-schema klass)
            (s/record klass {:b Bar4
                             :c LongOrString
-                            :p (sm/protocol PProtocol)})))
+                            :p (s/protocol PProtocol)})))
     (valid! klass (constructor (Bar4. [1] {}) 1 bar2))
     (valid! klass (constructor (Bar4. [1] {}) "hi" bar2))
     (invalid! klass (constructor (Bar4. [1] {}) "hi" bar1))
@@ -692,7 +691,7 @@
   (test-fancier-defrecord-schema NestedExplicit ->NestedExplicit))
 
 
-(sm/defrecord OddSum
+(s/defrecord OddSum
     [a b]
   {}
   #(odd? (+ (:a %) (:b %))))
@@ -702,7 +701,7 @@
   (invalid! OddSum (OddSum. 1 3)))
 
 #+clj
-(do (sm/defrecord RecordWithPrimitive [x :- long])
+(do (s/defrecord RecordWithPrimitive [x :- long])
     (deftest record-with-primitive-test
       (valid! RecordWithPrimitive (RecordWithPrimitive. 1))
       (is (thrown? Exception (RecordWithPrimitive. "a")))
@@ -733,9 +732,9 @@
 
 #+clj
 (deftest split-rest-arg-test
-  (is (= (schema.macros/split-rest-arg {} ['a '& 'b])
+  (is (= (macros/split-rest-arg {} ['a '& 'b])
          '[[a] b]))
-  (is (= (schema.macros/split-rest-arg {} ['a 'b])
+  (is (= (macros/split-rest-arg {} ['a 'b])
          '[[a b] nil])))
 
 ;;; fn
@@ -744,24 +743,24 @@
 
 (def +test-fn-schema+
   "Schema for (s/fn ^String [^OddLong x y])"
-  (sm/=> s/Str OddLong s/Any))
+  (s/=> s/Str OddLong s/Any))
 
 (deftest simple-validated-meta-test
-  (let [f (sm/fn ^s/Str foo [^OddLong arg0 arg1])]
+  (let [f (s/fn ^s/Str foo [^OddLong arg0 arg1])]
     (is (= +test-fn-schema+ (s/fn-schema f)))))
 
 (deftest no-schema-fn-test
-  (let [f (sm/fn [arg0 arg1] (+ arg0 arg1))]
-    (is (= (sm/=> s/Any s/Any s/Any) (s/fn-schema f)))
-    (sm/with-fn-validation
+  (let [f (s/fn [arg0 arg1] (+ arg0 arg1))]
+    (is (= (s/=> s/Any s/Any s/Any) (s/fn-schema f)))
+    (s/with-fn-validation
       (is (= 4 (f 1 3))))
     (is (= 4 (f 1 3)))))
 
 (deftest simple-validated-fn-test
-  (let [f (sm/fn test-fn :- (s/pred even?)
+  (let [f (s/fn test-fn :- (s/pred even?)
             [^s/Int x ^{:s {:foo (s/both s/Int (s/pred odd?))}} y]
             (+ x (:foo y -100)))]
-    (sm/with-fn-validation
+    (s/with-fn-validation
       (is (= 4 (f 1 {:foo 3})))
       ;; Primitive Interface Test
       #+clj (is (thrown? Exception (.invokePrim f 1 {:foo 3}))) ;; primitive type hints don't work on fns
@@ -774,11 +773,11 @@
     (testing
         "Tests that the anonymous function schema macro can handle a
          name, a schema without a name and no return schema."
-      (let [named-square (sm/fn square :- s/Int [x :- s/Int]
+      (let [named-square (s/fn square :- s/Int [x :- s/Int]
                            (* x x))
-            anon-square (sm/fn :- s/Int [x :- s/Int]
+            anon-square (s/fn :- s/Int [x :- s/Int]
                           (* x x))
-            arg-only-square (sm/fn [x :- s/Int] (* x x))]
+            arg-only-square (s/fn [x :- s/Int] (* x x))]
         (is (= 100
                (named-square 10)
                (anon-square 10)
@@ -787,7 +786,7 @@
 
 
 (deftest always-validated-fn-test
-  (let [f (sm/fn ^:always-validate test-fn :- (s/pred even?)
+  (let [f (s/fn ^:always-validate test-fn :- (s/pred even?)
             [x :- (s/pred pos?)]
             (inc x))]
     (is (= 2 (f 1)))
@@ -795,10 +794,10 @@
     (invalid-call! f -1)))
 
 (deftest never-validated-fn-test
-  (let [f (sm/fn ^:never-validate test-fn :- (s/pred even?)
+  (let [f (s/fn ^:never-validate test-fn :- (s/pred even?)
             [x :- (s/pred pos?)]
             (inc x))]
-    (sm/with-fn-validation
+    (s/with-fn-validation
       (is (= 2 (f 1)))
       (is (= 3 (f 2)))
       (is (= 0 (f -1))))))
@@ -809,62 +808,62 @@
 
 (deftest destructured-validated-fn-test
   (let [LongPair [(s/one s/Int 'x) (s/one s/Int 'y)]
-        f (sm/fn foo :- s/Int
+        f (s/fn foo :- s/Int
             [^LongPair [x y] ^s/Int arg1]
             (+ x y arg1))]
-    (is (= (sm/=> s/Int LongPair s/Int)
+    (is (= (s/=> s/Int LongPair s/Int)
            (s/fn-schema f)))
-    (sm/with-fn-validation
+    (s/with-fn-validation
       (is (= 6 (f [1 2] 3)))
       (invalid-call! f ["a" 2] 3))))
 
 (deftest two-arity-fn-test
-  (let [f (sm/fn foo :- s/Int
+  (let [f (s/fn foo :- s/Int
             ([^s/Str arg0 ^s/Int arg1] (+ arg1 (foo arg0)))
             ([^s/Str arg0] (parse-long arg0)))]
-    (is (= (sm/=>* s/Int [s/Str] [s/Str s/Int])
+    (is (= (s/=>* s/Int [s/Str] [s/Str s/Int])
            (s/fn-schema f)))
     (is (= 3 (f "3")))
     (is (= 10 (f "3" 7)))))
 
 (deftest infinite-arity-fn-test
-  (let [f (sm/fn foo :- s/Int
+  (let [f (s/fn foo :- s/Int
             ([^s/Int arg0] (inc arg0))
             ([^s/Int arg0  & ^{:s [s/Str]} strs]
                (reduce + (foo arg0) (map count strs))))]
-    (is (= (sm/=>* s/Int [s/Int] [s/Int & [s/Str]])
+    (is (= (s/=>* s/Int [s/Int] [s/Int & [s/Str]])
            (s/fn-schema f)))
-    (sm/with-fn-validation
+    (s/with-fn-validation
       (is (= 5 (f 4)))
       (is (= 16 (f 4 "55555" "666666")))
       (invalid-call! f 4 [3 3 3]))))
 
 (deftest rest-arg-destructuring-test
   (testing "no schema"
-    (let [f (sm/fn foo :- s/Int
+    (let [f (s/fn foo :- s/Int
               [^s/Int arg0 & [rest0]] (+ arg0 (or rest0 2)))]
-      (is (= (sm/=>* s/Int [s/Int & [(s/optional s/Any 'rest0)]])
+      (is (= (s/=>* s/Int [s/Int & [(s/optional s/Any 'rest0)]])
              (s/fn-schema f)))
-      (sm/with-fn-validation
+      (s/with-fn-validation
         (is (= 6 (f 4)))
         (is (= 9 (f 4 5)))
         (invalid-call! f 4 9 2))))
   (testing "arg schema"
-    (let [f (sm/fn foo :- s/Int
+    (let [f (s/fn foo :- s/Int
               [^s/Int arg0 & [rest0 :- s/Int]] (+ arg0 (or rest0 2)))]
-      (is (= (sm/=>* s/Int [s/Int & [(s/optional s/Int 'rest0)]])
+      (is (= (s/=>* s/Int [s/Int & [(s/optional s/Int 'rest0)]])
              (s/fn-schema f)))
-      (sm/with-fn-validation
+      (s/with-fn-validation
         (is (= 6 (f 4)))
         (is (= 9 (f 4 5)))
         (invalid-call! f 4 9 2)
         (invalid-call! f 4 1.5))))
   (testing "list schema"
-    (let [f (sm/fn foo :- s/Int
+    (let [f (s/fn foo :- s/Int
               [^s/Int arg0 & [rest0] :- [s/Int]] (+ arg0 (or rest0 2)))]
-      (is (= (sm/=>* s/Int [s/Int & [s/Int]])
+      (is (= (s/=>* s/Int [s/Int & [s/Int]])
              (s/fn-schema f)))
-      (sm/with-fn-validation
+      (s/with-fn-validation
         (is (= 6 (f 4)))
         (is (= 9 (f 4 5)))
         (is (= 9 (f 4 5 9)))
@@ -872,16 +871,16 @@
 
 (deftest fn-recursion-test
   (testing "non-tail recursion"
-    (let [f (sm/fn fib :- s/Int [n :- s/Int]
+    (let [f (s/fn fib :- s/Int [n :- s/Int]
               (if (<= n 2) 1 (+ (fib (- n 1)) (fib (- n 2)))))]
       (is (= 8 (f 6)))
-      (sm/with-fn-validation
+      (s/with-fn-validation
         (is (= 8 (f 6))))))
   (testing "tail recursion"
-    (let [f (sm/fn fact :- s/Int [n :- s/Int ret :- s/Int]
+    (let [f (s/fn fact :- s/Int [n :- s/Int ret :- s/Int]
               (if (<= n 1) ret (recur (dec n) (* ret n))))]
       (is (= 120 (f 5 1)))
-      (sm/with-fn-validation
+      (s/with-fn-validation
         (is (= 120 (f 5 1)))))))
 
 ;;; defn
@@ -889,19 +888,19 @@
 (def OddLongString
   (s/both s/Str (s/pred #(odd? (parse-long %)) 'odd-str?)))
 
-(sm/defn ^{:s OddLongString :tag String} simple-validated-defn
+(s/defn ^{:s OddLongString :tag String} simple-validated-defn
   "I am a simple schema fn"
   {:metadata :bla}
   [^OddLong arg0]
   (str arg0))
 
-(sm/defn ^{:tag String} simple-validated-defn-new :- OddLongString
+(s/defn ^{:tag String} simple-validated-defn-new :- OddLongString
   "I am a simple schema fn"
   {:metadata :bla}
   [arg0 :- OddLong]
   (str arg0))
 
-(sm/defn validated-pre-post-defn :- OddLong
+(s/defn validated-pre-post-defn :- OddLong
   "I have pre/post conditions"
   [arg0 :- s/Num]
   {:pre  [(odd? arg0) (> 10 arg0)]
@@ -909,30 +908,30 @@
   arg0)
 
 (def +simple-validated-defn-schema+
-  (sm/=> OddLongString OddLong))
+  (s/=> OddLongString OddLong))
 
 (def ^String +bad-input-str+ "Input to simple-validated-defn does not match schema")
 
 #+cljs
 (deftest simple-validated-defn-test
   (doseq [f [simple-validated-defn simple-validated-defn-new]]
-    (sm/with-fn-validation
+    (s/with-fn-validation
       (is (= "3" (f 3)))
       (invalid-call! f 4)
       (invalid-call! f "a")))
-  (sm/with-fn-validation
+  (s/with-fn-validation
     (is (= 7 (validated-pre-post-defn 7)))
     (is (thrown? AssertionError (validated-pre-post-defn 0)))
     (is (thrown? AssertionError (validated-pre-post-defn 11)))
     (is (thrown? AssertionError (validated-pre-post-defn 1)))
     (invalid-call! validated-pre-post-defn "a"))
-  (let [e (try (sm/with-fn-validation (simple-validated-defn 2)) nil
+  (let [e (try (s/with-fn-validation (simple-validated-defn 2)) nil
                (catch js/Error e e))]
     (is (>= (.indexOf (str e) +bad-input-str+) 0)))
   (is (= +simple-validated-defn-schema+ (s/fn-schema simple-validated-defn))))
 
 #+clj
-(sm/defn ^String multi-arglist-validated-defn :- OddLongString
+(s/defn ^String multi-arglist-validated-defn :- OddLongString
   "I am a multi-arglist schema fn"
   {:metadata :bla}
   ([arg0 :- OddLong]
@@ -951,7 +950,7 @@
   (is (= "Inputs: ([arg0 :- OddLong] [arg0 :- OddLong arg1 :- Long])\n  Returns: OddLongString\n\n  I am a multi-arglist schema fn"
          (:doc (meta #'multi-arglist-validated-defn))))
   (is (= '([arg0] [arg0 arg1]) (:arglists (meta #'multi-arglist-validated-defn))))
-  (sm/with-fn-validation
+  (s/with-fn-validation
     (testing "pre/post"
       (is (= 7 (validated-pre-post-defn 7)))
       (is (thrown-with-msg? AssertionError #"Assert failed: \(odd\? arg0\)"
@@ -969,7 +968,7 @@
         (is (= metadata :bla)))
       (is (= +simple-validated-defn-schema+ (s/fn-schema @v)))
 
-      (sm/with-fn-validation
+      (s/with-fn-validation
         (is (= "3" (@v 3)))
         (invalid-call! @v 4)
         (invalid-call! @v "a"))
@@ -980,7 +979,7 @@
     (is (.contains (.getClassName ^StackTraceElement (first (.getStackTrace e))) "simple_validated_defn"))
     (is (.startsWith (.getFileName ^StackTraceElement (first (.getStackTrace e))) "core_test.clj"))))
 
-(sm/defn ^:always-validate always-validated-defn :- (s/pred even?)
+(s/defn ^:always-validate always-validated-defn :- (s/pred even?)
   [x :- (s/pred pos?)]
   (inc x))
 
@@ -989,58 +988,58 @@
   (invalid-call! always-validated-defn 2)
   (invalid-call! always-validated-defn -1))
 
-(sm/defn fib :- s/Int [n :- s/Int]
+(s/defn fib :- s/Int [n :- s/Int]
   (if (<= n 2) 1 (+ (fib (- n 1)) (fib (- n 2)))))
 
-(sm/defn fact :- s/Int [n :- s/Int ret :- s/Int]
+(s/defn fact :- s/Int [n :- s/Int ret :- s/Int]
   (if (<= n 1) ret (recur (dec n) (* ret n))))
 
 
 (deftest defn-recursion-test
   (testing "non-tail recursion"
     (is (= 8 (fib 6)))
-    (sm/with-fn-validation
+    (s/with-fn-validation
       (is (= 8 (fib 6)))))
   (testing "tail recursion"
     (is (= 120 (fact 5 1)))
-    (sm/with-fn-validation
+    (s/with-fn-validation
       (is (= 120 (fact 5 1))))))
 
 ;; letfn
 
 (deftest minimal-letfn-test
   (is (= "1"
-         (sm/letfn
+         (s/letfn
              []
            "1"))))
 
 (deftest simple-letfn-test
   (is (= "1"
-         (sm/with-fn-validation
-           (sm/letfn
+         (s/with-fn-validation
+           (s/letfn
                [(x :- s/Num [] 1)
                 (y :- s/Str [m :- s/Num] (str m))]
              (y (x)))))))
 
 (deftest unannotated-letfn-test
   (is (= "1"
-         (sm/with-fn-validation
-           (sm/letfn
+         (s/with-fn-validation
+           (s/letfn
                [(x [] 1)
                 (y [m] (str m))]
              (y (x)))))))
 
 (deftest no-validation-letfn-test
   (is (= "1"
-         (sm/letfn
+         (s/letfn
              [(x :- s/Num [] 1)
               (y :- s/Str [m :- s/Num] (str m))]
            (y (x))))))
 
 (deftest error-letfn-test
   (is (thrown? #+clj RuntimeException #+cljs js/Error
-               (sm/with-fn-validation
-                 (sm/letfn
+               (s/with-fn-validation
+                 (s/letfn
                      [(x :- s/Num [] "1")
                       (y :- s/Str [m :- s/Num] (str m))]
                    (y (x)))))))
@@ -1050,13 +1049,13 @@
 (do
 
   (def +primitive-validated-defn-schema+
-    (sm/=> long OddLong))
+    (s/=> long OddLong))
 
-  (sm/defn ^long primitive-validated-defn
+  (s/defn ^long primitive-validated-defn
     [^long ^{:s OddLong} arg0]
     (inc arg0))
 
-  (sm/defn primitive-validated-defn-new :- long
+  (s/defn primitive-validated-defn-new :- long
     [^long arg0 :- OddLong]
     (inc arg0))
 
@@ -1067,14 +1066,14 @@
         (is (= +primitive-validated-defn-schema+ (s/fn-schema f)))
 
         (is ((ancestors (class f)) clojure.lang.IFn$LL))
-        (sm/with-fn-validation
+        (s/with-fn-validation
           (is (= 4 (f 3)))
           (is (= 4 (.invokePrim f 3)))
           (is (thrown? Exception (f 4))))
 
         (is (= 5 (f 4))))))
 
-  (sm/defn another-primitive-fn :- double
+  (s/defn another-primitive-fn :- double
     [^long arg0]
     1.0)
 
@@ -1085,26 +1084,26 @@
 
 (deftest with-fn-validation-error-test
   (is (thrown? #+clj RuntimeException #+cljs js/Error
-               (sm/with-fn-validation (throw #+clj (RuntimeException.) #+cljs (js/Error. "error")))))
+               (s/with-fn-validation (throw #+clj (RuntimeException.) #+cljs (js/Error. "error")))))
   (is (false? (.get_cell utils/use-fn-validation))))
 
 
 ;; def
 
 (deftest def-test ;; heh
-  (sm/def v 1)
+  (s/def v 1)
   (is (= 1 v))
-  (sm/def v "doc" 2)
+  (s/def v "doc" 2)
   (is (= 2 v))
   #+clj (is (= "doc" (:doc (meta #'v))))
-  (sm/def v :- s/Int "doc" 3)
+  (s/def v :- s/Int "doc" 3)
   (is (= 3 v))
   #+clj (is (= "doc" (:doc (meta #'v))))
-  (sm/def v :- s/Int 3)
+  (s/def v :- s/Int 3)
   #+clj (is (= String (:tag (meta (s/def v :- String "a")))))
-  #+clj (is (thrown? Exception (sm/def v :- s/Int "doc" 1.0)))
-  #+clj (is (thrown? Exception (sm/def v :- s/Int 1.0)))
-  #+clj (is (thrown? Exception (sm/def ^s/Int v 1.0))))
+  #+clj (is (thrown? Exception (s/def v :- s/Int "doc" 1.0)))
+  #+clj (is (thrown? Exception (s/def v :- s/Int 1.0)))
+  #+clj (is (thrown? Exception (s/def ^s/Int v 1.0))))
 
 
 ;; defmethod
@@ -1112,38 +1111,38 @@
 (defmulti m #(:k (first %&)))
 
 (deftest defmethod-unannotated-test
-  (sm/defmethod m :v [m x y] (+ x y))
+  (s/defmethod m :v [m x y] (+ x y))
   (is (= 3 (m {:k :v} 1 2))))
 
 (deftest defmethod-input-annotated
-  (sm/defmethod m :v [m :- {:k s/Keyword} x :- s/Num y :- s/Num] (+ x y))
+  (s/defmethod m :v [m :- {:k s/Keyword} x :- s/Num y :- s/Num] (+ x y))
   (is (= 3
-         (sm/with-fn-validation (m {:k :v} 1 2)))))
+         (s/with-fn-validation (m {:k :v} 1 2)))))
 
 (deftest defmethod-output-annotated
-  (sm/defmethod m :v :- s/Num [m x y] (+ x y))
+  (s/defmethod m :v :- s/Num [m x y] (+ x y))
   (is (= 3
-         (sm/with-fn-validation (m {:k :v} 1 2)))))
+         (s/with-fn-validation (m {:k :v} 1 2)))))
 
 (deftest defmethod-all-annotated
-  (sm/defmethod m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] (+ x y))
+  (s/defmethod m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] (+ x y))
   (is (= 3
-         (sm/with-fn-validation (m {:k :v} 1 2)))))
+         (s/with-fn-validation (m {:k :v} 1 2)))))
 
 (deftest defmethod-input-error-test
-  (sm/defmethod m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] (+ x y))
+  (s/defmethod m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] (+ x y))
   (is (thrown? #+clj RuntimeException #+cljs js/Error
-               (sm/with-fn-validation
-                 (sm/with-fn-validation (m {:k :v} 1 "2"))))))
+               (s/with-fn-validation
+                 (s/with-fn-validation (m {:k :v} 1 "2"))))))
 
 (deftest defmethod-output-error-test
-  (sm/defmethod m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] "wrong")
+  (s/defmethod m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] "wrong")
   (is (thrown? #+clj RuntimeException #+cljs js/Error
-               (sm/with-fn-validation
-                 (sm/with-fn-validation (m {:k :v} 1 2))))))
+               (s/with-fn-validation
+                 (s/with-fn-validation (m {:k :v} 1 2))))))
 
 (deftest defmethod-metadata-test
-  (sm/defmethod ^:always-validate m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] "wrong")
+  (s/defmethod ^:always-validate m :v :- s/Num [m :- {:k s/Keyword} x :- s/Num y :- s/Num] "wrong")
   (is (thrown? #+clj RuntimeException #+cljs js/Error
                (m {:k :v} 1 2))))
 
@@ -1162,7 +1161,7 @@
                       :b [1 :a]}
               "{:c missing-required-key, :b [(named (not (keyword? 1)) :k) (not (integer? :a))], :a #{[(not (integer? :a)) (not (integer? :b))]}}")))
 
-(sm/defrecord Explainer
+(s/defrecord Explainer
     [^s/Int foo ^s/Keyword bar]
   {(s/optional-key :baz) s/Keyword})
 
@@ -1183,7 +1182,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;  Helpers for defining schemas (used in in-progress work, expanlation coming soon)
 
-(sm/defschema TestFoo {:bar s/Str})
+(s/defschema TestFoo {:bar s/Str})
 
 (deftest test-defschema
   (is (= 'TestFoo (:name (meta TestFoo)))))


### PR DESCRIPTION
Based on #146 so please review that first. 

This PR continues that line of simplifying the core.  Commits and changelog are a good summary. Recapped:
- Prepare to remove `potemkin` as a dependency.  While we will continue to use it internally at Prismatic, there's no reason we need it as a dependency for everyone
  - Deprecate `*use-potemkin*` flag in preparation for removal.  Instead, there will be a different way to stub in a custom `defrecord` constructor if you want it.
  - In a future release, potemkin will be removed as an explicit dependency
- Stop using `potemkin/import-vars`, and move canonical implementations of `schema.macros` like `defn` to `schema.core`.
  - `import-vars` was causing issues with AOT compilation (see #137), which should hopefully be fixed.
  - The split of `core` and `macros` is no longer necessary since the introduction of `:include-macros` in ClojureScript, leading to a simpler interface
  - Use explicit temporary macro stubs to continue to support deprecated `schema.macros` invocations for now, without using `import-vars`.
- Increment minimum cljs version to support `:include-macros`
