### PR TITLE
Make process-fn-arity a parameter of process-fn-

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -258,7 +258,7 @@
 
 (clojure.core/defn process-fn-
   "Process the fn args into a final tag proposal, schema form, schema bindings, and fn form"
-  [env name fn-body]
+  [process-fn-arity env name fn-body]
   (let [output-schema (extract-schema-form name)
         output-schema-sym (gensym "output-schema")
         bind-meta (or (when-let [t (:tag (meta name))]
@@ -447,7 +447,7 @@
                   fn-args
                   (cons (gensym "fn") fn-args))
         [name more-fn-args] (extract-arrow-schematized-element &env fn-args)
-        {:keys [outer-bindings schema-form fn-body]} (process-fn- &env name more-fn-args)]
+        {:keys [outer-bindings schema-form fn-body]} (process-fn- process-fn-arity &env name more-fn-args)]
     `(let ~outer-bindings
        (schema.core/schematize-fn (clojure.core/fn ~name ~@fn-body) ~schema-form))))
 
@@ -519,7 +519,7 @@
   [& defn-args]
   (let [[name & more-defn-args] (normalized-defn-args &env defn-args)
         {:keys [doc tag] :as standard-meta} (meta name)
-        {:keys [outer-bindings schema-form fn-body arglists raw-arglists]} (process-fn- &env name more-defn-args)]
+        {:keys [outer-bindings schema-form fn-body arglists raw-arglists]} (process-fn- process-fn-arity &env name more-defn-args)]
     `(let ~outer-bindings
        (clojure.core/defn ~(with-meta name {})
          ~(assoc (apply dissoc standard-meta (when (primitive-sym? tag) [:tag]))


### PR DESCRIPTION
This makes it possible to reuse process-fn- as I do in the combifn and defcombifn macros as discussed here:
https://groups.google.com/d/msg/prismatic-plumbing/2BEQvdaUIRw/BO8yD_5PQdMJ
For now I copied process-fn- in my code and made that change and was successful in writing these macros while reusing most of the logic in schema.macros. When this PR is merged I'll be able to remove the duplicated process-fn- in my code.
