### PR TITLE
Both lein test and lein deploy work with new lein and dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,6 @@
                              [codox "0.8.8"]
                              [lein-cljsbuild "1.0.2"]
                              [com.cemerick/clojurescript.test "0.3.1"]]
-                   :hooks [leiningen.cljsbuild]
                    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl
                                                      cljx.repl-middleware/wrap-cljx]}
                    :cljx {:builds [{:source-paths ["src/cljx"]
@@ -30,14 +29,16 @@
                                     :rules :cljs}]}}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}}
 
-  :aliases {"all" ["with-profile" "dev:dev,1.5"]}
+  :aliases {"all" ["with-profile" "dev:dev,1.5"]
+            "deploy" ["do" "clean," "cljx" "once," "deploy" "clojars"]
+            "test" ["do" "clean," "cljx" "once," "test," "with-profile" "dev" "cljsbuild" "test"]}
 
   :jar-exclusions [#"\.cljx|\.swp|\.swo|\.DS_Store"]
 
   :lein-release {:deploy-via :shell
                  :shell ["lein" "deploy" "clojars"]}
 
-  :prep-tasks ["cljx" "javac" "compile"]
+  :auto-clean false
 
   :source-paths ["target/generated/src/clj" "src/clj"]
 
@@ -60,6 +61,7 @@
                                  :optimizations :whitespace
 
                                  :pretty-print true}}}}
+
   :codox {:src-uri-mapping {#"target/generated/src/clj" #(str "src/cljx/" % "x")}
           :src-dir-uri "http://github.com/prismatic/schema/blob/master/"
           :src-linenum-anchor-prefix "L"})


### PR DESCRIPTION
`lein deploy` didn't work with recent versions of lein and the latest project.clj.  

This may look like a small PR, but I spend 2+ hours reading docs, looking at other projects, and fiddling with various options to try to get the following to work: 
- tests work in both Clojure and ClojureScript
- deploy works without crashing
- no dependency on cljs or cljx in the deployed JAR

With the many things I tried, this appears to be a minimal changeset that achieves all options, but I might very well be missing something.  Please let me know if there are better options.  Thanks!
