### PR TITLE
Prep for 0.3.0 release (formerly 0.2.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.7
+## 0.3.0
  * **BREAKING** increase minimum clojurescript version 2120 to support :include-macros
  * **Deprecate** direct use of `schema.macros` in client code -- prefer canonical versions in `schema.core`
    in both Clojure and ClojureScript, using `:include-macros true` in cljs.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Clojure(Script) library for declarative data description and validation.
 
-Leiningen dependency (Clojars): `[prismatic/schema "0.2.6"]`. [Latest codox API docs](http://prismatic.github.io/schema).
+Leiningen dependency (Clojars): `[prismatic/schema "0.3.0"]`. [Latest codox API docs](http://prismatic.github.io/schema).
 
 **This is an alpha release. The API and organizational structure are
 subject to change. Comments and contributions are much appreciated.**

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject prismatic/schema "0.2.7-SNAPSHOT"
+(defproject prismatic/schema "0.3.0-SNAPSHOT"
   :description "Clojure(Script) library for declarative data description and validation"
   :url "http://github.com/prismatic/schema"
   :license {:name "Eclipse Public License"
@@ -36,7 +36,7 @@
   :jar-exclusions [#"\.cljx|\.swp|\.swo|\.DS_Store"]
 
   :lein-release {:deploy-via :shell
-                 :shell ["lein" "deploy" "clojars"]}
+                 :shell ["lein" "deploy"]}
 
   :auto-clean false
 


### PR DESCRIPTION
We'll call this 0.3.0 because of the breaking cljs dependency change, and the next breaking release (soon to follow) will be 0.4.0.  Also fixes lein-release in preparation for the release.
