### PR TITLE
Fix unprocessed rest arg when :never-validated

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -256,7 +256,8 @@
                                                       '~fn-name (pr-str error#))
                                        {:schema ~output-schema-sym :value o# :error error#})))
                            o#))))
-                   (cons bind body))}))
+                   (cons (into regular-args (when rest-arg ['& rest-arg]))
+                         body))}))
 
 (clojure.core/defn process-fn-
   "Process the fn args into a final tag proposal, schema form, schema bindings, and fn form"

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -793,14 +793,34 @@
     (invalid-call! f 2)
     (invalid-call! f -1)))
 
+
+(s/defn ^:never-validate never-validated-test-fn :- (s/pred even?)
+  [x :- (s/pred pos?)]
+  (inc x))
+
 (deftest never-validated-fn-test
-  (let [f (s/fn ^:never-validate test-fn :- (s/pred even?)
-            [x :- (s/pred pos?)]
-            (inc x))]
+  (doseq [f [never-validated-test-fn
+             (s/fn ^:never-validate test-fn :- (s/pred even?)
+               [x :- (s/pred pos?)]
+               (inc x))]]
     (s/with-fn-validation
       (is (= 2 (f 1)))
       (is (= 3 (f 2)))
       (is (= 0 (f -1))))))
+
+(s/defn ^:never-validate never-validated-rest-test-fn :- (s/pred even?)
+  [arg0 & [rest0 :- (s/pred pos?)]]
+  (+ arg0 (or rest0 2)))
+
+(deftest never-validated-rest-test
+  (doseq [f [never-validated-rest-test-fn
+             (s/fn ^:never-validate rest-test-fn :- (s/pred even?)
+               [arg0 & [rest0 :- (s/pred pos?)]]
+               (+ arg0 (or rest0 2)))]]
+    (s/with-fn-validation
+      (is (= 2 (f 0)))
+      (is (= 4 (f 2 2)))
+      (is (= 1 (f 2 -1))))))
 
 (defn parse-long [x]
   #+clj (Long/parseLong x)


### PR DESCRIPTION
When validation disabled via :never-validate meta and function is variadic,
any schemas and :- arrows on the rest arg were not getting removed from emitted
fn/defn form.

Schemas and :- arrows are removed from rest arg in `split-rest-arg`, which isn't
applied to `bind`. To fix, reconstruct the binding vector after
`split-rest-arg`.
