### PR TITLE
s/protocol captures the var not value, to support subsequent extensions in clj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.2
+ * Fix `s/protocol` in Clojure (didn't work properly with extends created later)
+
 ## 0.3.1
  * Fix Clojurescript compilation warnings/errors from accidental references to `clojure.data/diff` and `class` inside error messages. 
 

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -119,6 +119,12 @@
     (is (= '(pred odd?) (s/explain schema)))))
 
 (defprotocol ATestProtocol)
+
+(s/defn ^:always-validate a-test-protocol-fn
+  "Compile the schema before extending, make sure it works as expected"
+  [x :- (s/protocol ATestProtocol)]
+  x)
+
 (defrecord DirectTestProtocolSatisfier [] ATestProtocol)
 (defrecord IndirectTestProtocolSatisfier []) (extend-type IndirectTestProtocolSatisfier ATestProtocol)
 (defrecord NonTestProtocolSatisfier [])
@@ -130,6 +136,9 @@
     (invalid! schema (NonTestProtocolSatisfier.))
     (invalid! schema nil)
     (invalid! schema 117 "(not (satisfies? ATestProtocol 117))")
+    (is (a-test-protocol-fn (DirectTestProtocolSatisfier.)))
+    (is (a-test-protocol-fn (IndirectTestProtocolSatisfier.)))
+    (invalid-call! a-test-protocol-fn (NonTestProtocolSatisfier.))
     (is (= '(protocol ATestProtocol) (s/explain schema)))))
 
 (deftest regex-test


### PR DESCRIPTION
Fixes #164

Also simplifies the code, sine we just adopt the ClojureScript approach in Clojure.  
