### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Finally, we use validation with coercion for API inputs and outputs.  See the co
 
 ## More examples
 
-[`schema.core`](https://github.com/Prismatic/schema/blob/master/src/cljx/schema/core.cljx) provides a wealth of extra tools for defining schemas, which are described in docstrings and well-tested in [`schema.core-test`](https://github.com/Prismatic/schema/blob/master/test/cljx/schema/core_test.cljx).  We'll just touch on a few more examples here, and refer the reader to the code for more details and examples (for now).
+The source code in [schema/core.cljx](https://github.com/Prismatic/schema/blob/master/src/cljx/schema/core.cljx) provides a wealth of extra tools for defining schemas, which are described in docstrings. The file [schema/core_test.cljx](https://github.com/Prismatic/schema/blob/master/test/cljx/schema/core_test.cljx) demonstrates a variety of sample schemas and many examples of passing & failing clojure data.  We'll just touch on a few more examples here, and refer the reader to the code for more details and examples (for now).
 
 ### Map schema details
 


### PR DESCRIPTION
Despite many readings, I missed the two links to core.cljx and core_test.cljx.  Doh!

I think the links would be more obvious (and be more readily recognized in importance) with some mods. 
1. Remove the "source code" formatting
2. Modify the text to more clearly indicate these are 2 source code files
3. Replace the namespace name with the filename to emphasize #2

Does this look OK?
Alan
