### PR TITLE
Add `Dunno` and `Approx` utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,26 @@ Similarly, you can also write sequence schemas that expect particular values in 
 
 You can also define schemas for [recursive data types](https://github.com/Prismatic/schema/wiki/Recursive-Schemas), or create [your own custom schemas types](https://github.com/Prismatic/schema/wiki/Defining-New-Schema-Types-1.0).
 
+### Working backwards
+
+When adding schemas to already-existing code, you may find it useful work in
+stages: initially describing the shapes of expected data with broad strokes,
+gradually refining the schemas as your understanding of the domain improves. To
+remind yourself and others that certain schemas are not yet precise, you can use
+`Dunno` (an alias for `Any`) and `Approx` (a no-op macro).
+
+Some example usages:
+
+```clojure
+(def Username (Approx Str))  ; there may be length requirements or character restrictions
+(def ApiResponse
+  {:started-by Username
+   :affected #{Username}
+   :completed? (Approx Bool)  ; not sure if it's ever nil
+   :initiated-at (Approx Str)  ; an RFC-3339 timestamp
+   :result {Dunno Dunno}})
+```
+
 ## Transformations and Coercion
 
 As of version 0.2.0, Schema supports schema-driven data transformations, with *coercion* being the main application fleshed out thus far.  Coercion is like validation, except a schema-dependent transformation can be applied to the input data before validation.

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -362,3 +362,8 @@
    See (doc compile-fn-validation?) for all conditions which control fn validation compilation"
   [on?]
   (reset! *compile-fn-validation* on?))
+
+(defmacro Approx
+  "A no-op “tag” to mark a schema as only *approximately* constraining the type."
+  [x]
+  x)

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -244,6 +244,10 @@
   "Any value, including nil."
   (AnythingSchema. nil))
 
+(def Dunno
+  "I.e., “I don’t *know* that *any* value is acceptable; I just don’t want to
+  deal with refining the schema any more right now.”"
+  Any)
 
 ;;; eq (to a single allowed value)
 


### PR DESCRIPTION
(The justification for these additions is in [this commit](https://github.com/MerelyAPseudonym/schema/commit/0bea7becba88d328bf372c1d12f878bd85030389?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8))

Assuming you even like the idea of `Dunno` and/or `Approx`, I'm totally open to polishing the PR. Just let me know.