### PR TITLE
support vars

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -244,6 +244,14 @@
   "Any value, including nil."
   (AnythingSchema. nil))
 
+;; Vars can contain schema
+
+(extend-protocol Schema
+  #+clj clojure.lang.Var #+cljs cljs.core.Var
+  (spec [this]
+    (spec (deref this)))
+  (explain [this]
+    (explain (deref this))))
 
 ;;; eq (to a single allowed value)
 

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -95,6 +95,10 @@
   (valid! s/Any :whatever)
   (is (= 'Any (s/explain s/Any))))
 
+(deftest var-test
+  (valid! #'s/Any 10)
+  (is (= 'Any (s/explain #'s/Any))))
+
 (deftest eq-test
   (let [schema (s/eq 10)]
     (valid! schema 10)


### PR DESCRIPTION
Provides support for Vars. Defines schema with subschema as vars can provide substantial printing improvements as well as other potentially useful info without changing anything about the schema format.