### PR TITLE
Fix sequence generation (fixes #321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+ * **BREAKING** change the internal details of collection specs (should only be an issue for custom collection schemas that don't rely on helpers `one-element` or `all-elements`).
+ * Fix generation for sequence schemas containing a non-trailing `s/optional` element.
+
 ## 1.0.6
  * Install a pprint method that uses the explain, in addition to an ordinary print-method.  Should fix large prints and stack overflows while pprinting schemas, or with plugins such as `pretty`.
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ You can also define schemas for [recursive data types](https://github.com/plumat
 
 ## Transformations and Coercion
 
-As of version 0.2.0, Schema supports schema-driven data transformations, with *coercion* being the main application fleshed out thus far.  Coercion is like validation, except a schema-dependent transformation can be applied to the input data before validation.
+Schema also supports schema-driven data transformations, with *coercion* being the main application fleshed out thus far.  Coercion is like validation, except a schema-dependent transformation can be applied to the input data before validation.
 
 An example application of coercion is converting parsed JSON (e.g., from an HTTP post request) to a domain object with a richer set of types (e.g., Keywords).
 
@@ -426,7 +426,7 @@ If you make something new, please feel free to PR to add it here!
 
 ## Supported Clojure versions
 
-Schema is currently supported on 1.6 and 1.7 and the latest version of ClojureScript.
+Schema is currently supported on 1.6 through 1.8 and the latest version of ClojureScript.
 
 ## License
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject prismatic/schema "1.0.6-SNAPSHOT"
+(defproject prismatic/schema "1.1.0-SNAPSHOT"
   :description "Clojure(Script) library for declarative data description and validation"
   :url "http://github.com/plumatic/schema"
   :license {:name "Eclipse Public License"

--- a/src/clj/schema/experimental/generators.clj
+++ b/src/clj/schema/experimental/generators.clj
@@ -30,6 +30,30 @@
     (fn [d] (#'generators/make-gen (fn [r s] (generators/call-gen @d r (quot s 2)))))
     (fn [] (subschema-generator schema params))))
 
+
+;; Helpers for collections
+
+(declare elements-generator)
+
+(defn element-generator [e params]
+  (if (vector? e)
+    (case (first e)
+      ::schema.spec.collection/optional
+      (generators/one-of
+       [(generators/return nil)
+        (elements-generator (next e) params)])
+
+      ::schema.spec.collection/remaining
+      (do (macros/assert! (= 2 (count e)) "remaining can have only one schema.")
+          (generators/vector (sub-generator (second e) params))))
+    (generators/fmap vector (sub-generator e params))))
+
+(defn elements-generator [elts params]
+  (->> elts
+       (map #(element-generator % params))
+       (apply generators/tuple)
+       (generators/fmap (partial apply concat))))
+
 (defprotocol CompositeGenerator
   (composite-generator [s params]))
 
@@ -55,16 +79,7 @@
   (composite-generator [s params]
     (generators/such-that
      (complement (.-pre ^schema.spec.collection.CollectionSpec s))
-     (generators/fmap
-      (comp (:constructor s) (partial apply concat))
-      (apply
-       generators/tuple
-       (for [{:keys [cardinality] :as e} (:elements s)]
-         (let [g (sub-generator e params)]
-           (case cardinality
-             :exactly-one (generators/fmap vector g)
-             :at-most-one (generators/one-of [(generators/return nil) (generators/fmap vector g)])
-             :zero-or-more (generators/vector g))))))))
+     (generators/fmap (:constructor s) (elements-generator (:elements s) params))))
 
   schema.spec.leaf.LeafSpec
   (composite-generator [s params]

--- a/test/clj/schema/experimental/generators_test.clj
+++ b/test/clj/schema/experimental/generators_test.clj
@@ -45,6 +45,17 @@
     (testing (str leaf-schema)
       (is (= 10 (count (generators/sample 10 leaf-schema)))))))
 
+(def FancySeq
+  "A sequence that starts with a String, followed by an optional Keyword,
+   followed by any number of Numbers."
+  [(s/one s/Str "s")
+   (s/optional s/Keyword "k")
+   s/Num])
+
+(deftest fancy-seq-smoke-test
+  "Catch issues wit a fancier schema with optional keys and such."
+  (is (= 100 (count (generators/sample 100 FancySeq)))))
+
 (check-clojure-test/defspec spec-test
   100
   (properties/for-all [x (generators/generator OGSchema)]

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -1332,29 +1332,24 @@
   s/Schema
   (spec [this]
     (collection/collection-spec
-      (let [p (spec/precondition this #(instance? ItemTest %) #(list 'instance? ItemTest %))]
-        (if-let [evf (:extra-validator-fn this)]
-          (some-fn p (spec/precondition this evf #(list 'passes-extra-validation? %)))
-          p))
-      (fn [x] x)
-      [{:schema     s/Int
-        :cardinality :exactly-one
-        :parser     (fn [item-col m]
-                      (item-col (:first m))
+     (let [p (spec/precondition this #(instance? ItemTest %) #(list 'instance? ItemTest %))]
+       (if-let [evf (:extra-validator-fn this)]
+         (some-fn p (spec/precondition this evf #(list 'passes-extra-validation? %)))
+         p))
+     (fn [x] x)
+     [{:schema     s/Int
+       :parser     (fn [item-col m]
+                     (item-col (:first m))
+                     m)
+       :error-wrap (fn [err] [:first (utils/error-val err)])}
+      {:schema      schema
+       :parser      (fn [item-col m]
+                      (item-col (:second m))
                       m)
-        :error-wrap (fn [err] [:first (utils/error-val err)])
-        }
-       {:schema      schema
-        :cardinality :exactly-one
-        :parser      (fn [item-col m]
-                       (item-col (:second m))
-                       m)
-        :error-wrap  (fn [err] [:second (utils/error-val err)])
-        }
-       {:schema s/Any
-        :cardinality :exactly-one
-        :parser (fn [_ _] nil)}]
-      (fn [_ elts _] (map utils/error-val elts))))
+       :error-wrap  (fn [err] [:second (utils/error-val err)])}
+      {:schema s/Any
+       :parser (fn [_ _] nil)}]
+     (fn [_ elts _] (map utils/error-val elts))))
   (explain [_]
     (list 'cache-test)))
 


### PR DESCRIPTION
The existing `:cardinality` key was not expressive enough to capture the semantics of sequence schemas (namely, that if you don't generate an `s/optional` element, you have to stop there.  

This PR replaces `:cardinality` with a nested structure of optional tails that can properly express the semantics of existing collection schemas for the purpose of generation.  It also slightly generalizes the types of schemas that can be expressed with the collection spec, although probably not in a way that's useful to anyone.

The changes feel a bit heavyweight for what's accomplished, but I tried a few alternatives and couldn't get them to work without reasonable performance (and really didn't feel good about the option of adding another pseudo-`:cardinality` that expressed the missing constraint.  Suggestions for alternative approaches very welcome!  