### PR TITLE
Atomize simple cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.1
+ * Fix (at least some) AOT issues around PSimpleCell/SimpleVCell, by replacing with atom/AtomicReference.
+
 ## 1.1.0
  * **Deprecate* schema.experimental.generators and schema.experimental.complete.  Find them in their new home in the separate schema-generators project.
  * **BREAKING** change the internal details of collection specs (should only be an issue for custom collection schemas that don't rely on helpers `one-element` or `all-elements`).

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -225,7 +225,7 @@
                         metad-bind-syms)
                       `(let [validate# ~(if (:always-validate (meta fn-name))
                                           `true
-                                          `(.get_cell ~'ufv__))]
+                                          `(if-cljs (deref ~'ufv__) (.get ~'ufv__)))]
                          (when validate#
                            (let [args# ~(if rest-arg
                                           `(list* ~@bind-syms ~rest-sym)
@@ -264,7 +264,7 @@
         fn-forms (map :arity-form processed-arities)]
     {:outer-bindings (vec (concat
                            (when compile-validation
-                             `[~(with-meta 'ufv__ {:tag 'schema.utils.PSimpleCell}) schema.utils/use-fn-validation])
+                             `[~(with-meta 'ufv__ {:tag 'java.util.concurrent.atomic.AtomicReference}) schema.utils/use-fn-validation])
                            [output-schema-sym output-schema]
                            (apply concat schema-bindings)
                            (mapcat :more-bindings processed-arities)))

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -1171,12 +1171,14 @@
 (clojure.core/defn fn-validation?
   "Get the current global schema validation setting."
   []
-  (.get_cell ^schema.utils.PSimpleCell utils/use-fn-validation))
+  #+clj (.get ^java.util.concurrent.atomic.AtomicReference utils/use-fn-validation)
+  #+cljs @utils/use-fn-validation)
 
 (clojure.core/defn set-fn-validation!
   "Globally turn on (or off) schema validation for all s/fn and s/defn instances."
   [on?]
-  (.set_cell ^schema.utils.PSimpleCell utils/use-fn-validation on?))
+  #+clj (.set ^java.util.concurrent.atomic.AtomicReference utils/use-fn-validation on?)
+  #+cljs (reset! utils/use-fn-validation on?))
 
 (defmacro with-fn-validation
   "Execute body with input and output schema validation turned on for

--- a/src/cljx/schema/utils.cljx
+++ b/src/cljx/schema/utils.cljx
@@ -164,30 +164,10 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Utilities for fast-as-possible reference to use to turn fn schema validation on/off
 
-#+clj
-(definterface PSimpleCell
-  (get_cell ^boolean [])
-  (set_cell [^boolean x]))
-
-#+cljs
-(defprotocol PSimpleCell
-  (get_cell [this])
-  (set_cell [this x]))
-
-
-;; adds ~5% overhead compared to no check
-(deftype SimpleVCell [^:volatile-mutable ^boolean q]
-  PSimpleCell
-  (get_cell [this] q)
-  (set_cell [this x] (set! q x)))
-
 (def use-fn-validation
   "Turn on run-time function validation for functions compiled when
    s/compile-fn-validation was true -- has no effect for functions compiled
    when it is false."
-  (SimpleVCell. false))
-
-#+cljs
-(do
-  (set! (.-get_cell use-fn-validation) (partial get_cell use-fn-validation))
-  (set! (.-set_cell use-fn-validation) (partial set_cell use-fn-validation)))
+  ;; specialize in Clojure for performance
+  #+clj (java.util.concurrent.atomic.AtomicReference. false)
+  #+cljs (atom false))

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -1221,7 +1221,7 @@
 (deftest with-fn-validation-error-test
   (is (thrown? #+clj RuntimeException #+cljs js/Error
                (s/with-fn-validation (throw #+clj (RuntimeException.) #+cljs (js/Error. "error")))))
-  (is (false? (.get_cell utils/use-fn-validation))))
+  (is (false? (s/fn-validation?))))
 
 
 ;; def


### PR DESCRIPTION
Fixes #355, and hopefully #354 formerly known as #351. 

Replaces the custom bool container class with an atom (or bare AtomicReference in Clojure) -- keeping the same performance without the headaches from Class generation.