### PR TITLE
Allow custom fn validation

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -1206,6 +1206,22 @@
          (try (body#) (finally (set-fn-validation! true))))
        (body#))))
 
+(def fn-validator
+  "A var that can be rebound to a function to customize the behavior
+  of fn validation. When fn validation is on and `fn-validator` is
+  bound to a function, normal argument and return value checks will
+  be substituted with a call to this function with five arguments:
+
+    direction   - :input or :output
+    fn-name     - a symbol, the function's name
+    schema      - the schema for the arglist or the return value
+    checker     - a precompiled checker to check a value against
+                  the schema
+    value       - the actual arglist or return value
+
+  The function's return value will be ignored."
+  nil)
+
 (clojure.core/defn schematize-fn
   "Attach the schema to fn f at runtime, extractable by fn-schema."
   [f schema]

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -1387,3 +1387,21 @@
 
 (deftest schema-ns-test
   (is (= 'schema.core-test (s/schema-ns TestFoo))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;  Testing the ability to redefine schema.macros/fn-validator
+
+(deftest soft-validation-test
+  (let [the-log (atom [])
+        log #(swap! the-log conj %&)]
+    (with-redefs [s/fn-validator
+                  (fn [dir fn-name schema checker value]
+                    (when-let [err (checker value)]
+                      (log dir fn-name value)))]
+      (s/with-fn-validation
+        (simple-validated-defn 12)
+        (simple-validated-defn 13)))
+    (is (= [[:input 'simple-validated-defn [12]]
+            [:output 'simple-validated-defn "12"]]
+           @the-log))))


### PR DESCRIPTION
this is a proof-of-concept for being able to customize the fn-validation logic (by setting `use-fn-validation` to a function), which lets you implement things like:

1. soft runtime checks that only log warnings (or something) on schema failures
2. soft runtime checks that only happen a small percentage of the time to minimize the performance cost

I'd be happy to tweak, add tests, etc. if this is a desired feature.

The main use case for this for me is when retrofitting schemas on a legacy project, it's nice to be able to deploy the schemas to production to get feedback about their correctness without causing exceptions to be thrown.