### PR TITLE
Add map entry constructor that returns values of the correct type

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -747,13 +747,17 @@
   (or (required-key? ks)
       (optional-key? ks)))
 
+(clojure.core/defn map-entry-ctor [[k v :as coll]]
+  #+clj (clojure.lang.MapEntry. k v)
+  #+cljs (vec coll))
+
 ;; A schema for a single map entry.
 (clojure.core/defrecord MapEntry [key-schema val-schema]
   Schema
   (spec [this]
     (collection/collection-spec
      spec/+no-precondition+
-     vec
+     map-entry-ctor
      [(collection/one-element true key-schema (clojure.core/fn [item-fn e] (item-fn (key e)) e))
       (collection/one-element true val-schema (clojure.core/fn [item-fn e] (item-fn (val e)) nil))]
      (clojure.core/fn [[k] [xk xv] _]

--- a/test/cljx/schema/coerce_test.cljx
+++ b/test/cljx/schema/coerce_test.cljx
@@ -92,3 +92,10 @@
 (deftest constrained-test
   (is (= 1 ((coerce/coercer! (s/constrained s/Int odd?) coerce/string-coercion-matcher) "1")))
   (is (= {1 1} ((coerce/coercer! (s/constrained {s/Int s/Int} #(odd? (count %))) coerce/string-coercion-matcher) {"1" "1"}))))
+
+(deftest map-entry-test
+  (let [entry (first {:foo :bar})
+        coercer (coerce/coercer! (s/map-entry s/Any s/Any) (constantly nil))
+        coerced-value (coercer entry)]
+    (is (= entry coerced-value))
+    (is (= (type entry) (type coerced-value)))))


### PR DESCRIPTION
The other day I was tracking down a weird bug in a clojure project and narrowed it down to the following inconsistency:

```clojure
(type (first {:asdf "asdf"}))
=> clojure.lang.MapEntry

(type ((schema.coerce/coercer
         (schema.core/map-entry (schema.core/eq :asdf) sc/Str)
         (constantly nil))
        (first {:asdf "asdf"})))
=> clojure.lang.PersistentVector
```

Given a coercer with a coercion matcher that always returns nil, map entries are being changed into vectors. I would assume such a nil coercer to always return the unaltered input or something very close to that.

Added a test to force the code change and updated the contstructor the MapEntry schema uses.