### PR TITLE
Add schema validation error highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased] 1.1.4
+ * Highlights schema validation errors
+
 ## 1.1.3 
  * Make fn validation customizable by addition of `fn-validator` function
 

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -237,7 +237,7 @@
                                                          @~input-checker-sym
                                                          args#)
                                (when-let [error# (@~input-checker-sym args#)]
-                                 (error! (utils/format* "Input to %s does not match schema: %s"
+                                 (error! (utils/format* "Input to %s does not match schema: \n\n\t \033[0;33m  %s \033[0m \n\n"
                                                         '~fn-name (pr-str error#))
                                          {:schema ~input-schema-sym :value args# :error error#})))))
                          (let [o# (loop ~(into (vec (interleave (map #(with-meta % {}) bind) bind-syms))
@@ -251,7 +251,7 @@
                                                          @~output-checker-sym
                                                          o#)
                                (when-let [error# (@~output-checker-sym o#)]
-                                 (error! (utils/format* "Output of %s does not match schema: %s"
+                                 (error! (utils/format* "Output of %s does not match schema: \n\n\t \033[0;33m  %s \033[0m \n\n"
                                                         '~fn-name (pr-str error#))
                                          {:schema ~output-schema-sym :value o# :error error#}))))
                            o#))))


### PR DESCRIPTION
Adds _breaklines_ and _yellow color_ on the schema error in order to have a **cleaner and better to read message**;

> Before:
> ![screen shot 2017-03-17 at 17 28 29](https://cloud.githubusercontent.com/assets/8419301/24061712/490acda4-0b37-11e7-9351-76516281db82.png)


> After:
> ![screen shot 2017-03-17 at 17 25 43](https://cloud.githubusercontent.com/assets/8419301/24061716/4dc07272-0b37-11e7-8984-449d722ef5b1.png)




