### PR TITLE
Revert "Pretty print data from schema validation errors"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.6
+ * Revert pretty printing of validation errors to remove reflection and fix stack traces.
+ * Add float type to JVM coercers.
+
+## 1.1.5
+ * Pretty print schema validation errors
+
 ## 1.1.4
  * Highlights schema validation errors
  * Fix an issue with `isa?` and the global hierarchy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-## 1.1.5
- * Pretty print schema validation errors
-
 ## 1.1.4
  * Highlights schema validation errors
  * Fix an issue with `isa?` and the global hierarchy

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -30,14 +30,6 @@
       (try ~@try-body (~'catch js/Object ~sym ~@catch-body))
       (try ~@try-body (~'catch Throwable ~sym ~@catch-body)))))
 
-(defn pretty-exception-info
-  "Proxy of ExceptionInfo that pretty prints data"
-  [message data]
-  (proxy [clojure.lang.ExceptionInfo] [message data]
-    (toString [] (str "clojure.lang.ExceptionInfo: "
-                      (proxy-super getMessage) " "
-                      (with-out-str (clojure.pprint/pprint (proxy-super getData)))))))
-
 (defmacro error!
   "Generate a cross-platform exception appropriate to the macroexpansion context"
   ([s]
@@ -48,7 +40,7 @@
      (let [m (merge {:type :schema.core/error} m)]
        `(if-cljs
          (throw (ex-info ~s ~m))
-         (throw (pretty-exception-info ~(with-meta s `{:tag java.lang.String}) ~m))))))
+         (throw (clojure.lang.ExceptionInfo. ~(with-meta s `{:tag java.lang.String}) ~m))))))
 
 (defmacro safe-get
   "Like get but throw an exception if not found.  A macro just to work around cljx function


### PR DESCRIPTION
Reverts plumatic/schema#386

@phillipm This PR introduced reflection and broke the stack traces.  My bad before not running the tests before pushing a new version, I don't have Clojure installed on my main laptop anymore.  Happy to take a version of this that doesn't cause reflection and doesn't pollute the stack traces from s/defn validation errors. 