### PR TITLE
Exclude MapEntry and ->MapEntry

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -75,7 +75,7 @@
    See the docstrings of defrecord, fn, and defn for more details about how
    to use these macros."
   ;; don't exclude def because it's not a var.
-  (:refer-clojure :exclude [Keyword Symbol Inst atom defrecord defn letfn defmethod fn])
+  (:refer-clojure :exclude [Keyword Symbol Inst atom defrecord defn letfn defmethod fn MapEntry ->MapEntry])
   (:require
    #+clj [clojure.pprint :as pprint]
    [clojure.string :as str]


### PR DESCRIPTION
Clojurescript 1.9.542 adds the MapEntry type:
https://dev.clojure.org/jira/browse/CLJS-2013

Compiling with Schema 1.1.5 and ClojureScript 1.9.542
gives a warning about MapEntry being overwritten by schema.core.

Fixes #392 