### PR TITLE
Use fully qualified keyword

### DIFF
--- a/src/clj/schema/experimental/generators.clj
+++ b/src/clj/schema/experimental/generators.clj
@@ -39,12 +39,12 @@
 (defn element-generator [e params]
   (if (vector? e)
     (case (first e)
-      ::schema.spec.collection/optional
+      :schema.spec.collection/optional
       (generators/one-of
        [(generators/return nil)
         (elements-generator (next e) params)])
 
-      ::schema.spec.collection/remaining
+      :schema.spec.collection/remaining
       (do (macros/assert! (= 2 (count e)) "remaining can have only one schema.")
           (generators/vector (sub-generator (second e) params))))
     (generators/fmap vector (sub-generator e params))))


### PR DESCRIPTION
The :: syntax is used for autoresolving things in the current namespace, ie aliases, it doesn't work with fully qualified names as those aren't in the current ns.

```
Clojure 1.9.0-beta1
Java HotSpot(TM) 64-Bit Server VM 1.8.0_131-b11
        Exit: Control+D or (exit) or (quit)
    Commands: (user/help)
        Docs: (doc function-name-here)
              (find-doc "part-of-name-here")
Find by Name: (find-name "part-of-name-here")
      Source: (source function-name-here)
     Javadoc: (javadoc java-object-or-class-here)
    Examples from clojuredocs.org: [clojuredocs or cdoc]
              (user/clojuredocs name-here)
              (user/clojuredocs "ns-here" "name-here")
boot.user=> (require '[clojure.core :as core])
nil
boot.user=> ::clojure.core/foo

clojure.lang.LispReader$ReaderException: java.lang.RuntimeException: Invalid token: ::clojure.core/foo
             java.lang.RuntimeException: Invalid token: ::clojure.core/foo
boot.user=> :clojure.core/foo
:clojure.core/foo
boot.user=> ::core/foo
:clojure.core/foo
```