### PR TITLE
Error message for multimethods should include the function name

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -1365,11 +1365,11 @@
     (cljs.core/-add-method
      ~(with-meta multifn {:tag 'cljs.core/MultiFn})
      ~dispatch-val
-     (fn ~(with-meta (gensym) (meta multifn)) ~@fn-tail))
+     (fn ~(with-meta (gensym (str multifn "__")) (meta multifn)) ~@fn-tail))
     (. ~(with-meta multifn {:tag 'clojure.lang.MultiFn})
        addMethod
        ~dispatch-val
-       (fn ~(with-meta (gensym) (meta multifn)) ~@fn-tail))))
+       (fn ~(with-meta (gensym (str multifn "__")) (meta multifn)) ~@fn-tail))))
 
 (defmacro letfn
   "s/letfn : s/fn :: clojure.core/letfn : clojure.core/fn"

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -1410,3 +1410,18 @@
     (is (= [[:input 'simple-validated-defn [12]]
             [:output 'simple-validated-defn "12"]]
            @the-log))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;  Testing that error messages on multimethods include the name
+
+(defmulti ffbe878f identity)
+(s/defmethod ^:always-validate ffbe878f 42
+  [x :- s/Str]
+  :unreachable)
+
+(deftest multimethod-error-messages
+  (try
+    (ffbe878f 42)
+    (is false "unreachable")
+    (catch Exception e
+      (is (re-find #"ffbe878f" (str e))))))


### PR DESCRIPTION
It will be a derivative gensym in this case, but that's probably the
best that can be done easily. Otherwise it's a completely generic gensym
like `G__4872`, which makes debugging difficult.