### PR TITLE
Fix for defmethod across aliased ns

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -1365,11 +1365,11 @@
     (cljs.core/-add-method
      ~(with-meta multifn {:tag 'cljs.core/MultiFn})
      ~dispatch-val
-     (fn ~(with-meta (gensym (str multifn "__")) (meta multifn)) ~@fn-tail))
+     (fn ~(with-meta (gensym (str (name multifn) "__")) (meta multifn)) ~@fn-tail))
     (. ~(with-meta multifn {:tag 'clojure.lang.MultiFn})
        addMethod
        ~dispatch-val
-       (fn ~(with-meta (gensym (str multifn "__")) (meta multifn)) ~@fn-tail))))
+       (fn ~(with-meta (gensym (str (name multifn) "__")) (meta multifn)) ~@fn-tail))))
 
 (defmacro letfn
   "s/letfn : s/fn :: clojure.core/letfn : clojure.core/fn"


### PR DESCRIPTION
I think with #401 we lost the ability to defmethod an aliased symbol, e.g.:

```clojure
(require '[schema.core :as s])
(require '[foo.bar :as bar])
(s/defmethod bar/some-method ...)
```

Because `(gensym 'bar/some-method)` creates a qualified symbol that causes clojure.core/defmethod to barf.

I think this PR fixes it.