### PR TITLE
Use `uuid` in CLJS to avoid warnings

### DIFF
--- a/src/cljx/schema/coerce.cljx
+++ b/src/cljx/schema/coerce.cljx
@@ -105,7 +105,7 @@
   #+clj
   (safe #(java.util.UUID/fromString ^String %))
   #+cljs
-  #(if (string? %) (cljs.core.UUID. %) %))
+  #(if (string? %) (uuid %) %))
 
 
 (def ^:no-doc +json-coercions+


### PR DESCRIPTION
Compiling latest Schema with latest CLJS (1.10.439) + Shadow CLJS latest (2.7.15) generates the warning:

```
------ WARNING #1 --------------------------------------------------------------
 File: schema/coerce.cljs:108:20
--------------------------------------------------------------------------------
 105 |
 106 |
 107 |
 108 |   #(if (string? %) (cljs.core.UUID. %) %))
--------------------------^-----------------------------------------------------
 Wrong number of args (1) passed to cljs.core.UUID
--------------------------------------------------------------------------------
 109 |
 110 |
 111 | (def ^:no-doc +json-coercions+
 112 |   (merge
--------------------------------------------------------------------------------
```

This PR uses the simple `uuid` fn from cljs core that fixes the warning.