### PR TITLE
Don't catch Throwable on the JVM

### DIFF
--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -28,7 +28,7 @@
     (assert (symbol? sym))
     `(if-cljs
       (try ~@try-body (~'catch js/Object ~sym ~@catch-body))
-      (try ~@try-body (~'catch Throwable ~sym ~@catch-body)))))
+      (try ~@try-body (~'catch Exception ~sym ~@catch-body)))))
 
 (defmacro error!
   "Generate a cross-platform exception appropriate to the macroexpansion context"


### PR DESCRIPTION
I don't think catching `Throwable` is a good thing for schema to be doing.

This came up when I was running a repl thread that was doing lots of schema completer work, and I couldn't `(.stop thread)` it. Presumably schema was catching the `ThreadDeath` exception and turning it into a completer error.

I think that kind of thing is indicative of the difference between catching & swallowing `Exception` vs `Throwable`.