### PR TITLE
Don't swallow fatal exceptions

### DIFF
--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -288,7 +288,16 @@
       (is (= '(conditional odd? Int)
              (s/explain (s/conditional odd? s/Int))))
       (is (= '(conditional odd? Int weird?)
-             (s/explain (s/conditional odd? s/Int 'weird?)))))))
+             (s/explain (s/conditional odd? s/Int 'weird?))))))
+  (testing "nonfatal exceptions are caught"
+    (let [schema (s/conditional (fn [x] (throw (ex-info "non-fatal error" {})))
+                                s/Int)]
+      (invalid! schema 99)))
+  #+clj
+  (testing "fatal exceptions are not caught"
+    (let [schema (s/conditional (fn [x] (throw (InterruptedException.)))
+                                s/Int)]
+      (is (thrown? InterruptedException (s/validate schema 42))))))
 
 (deftest cond-pre-test
   (let [s (s/cond-pre


### PR DESCRIPTION
Supercedes #412

Some JVM exception types are too severe to be caught and interpreted
as schema failures. This commit adds a short whitelist of those types
and re-throws them.