### PR TITLE
Modernize dev/test setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2.0
+
+jobs:
+  build:
+    docker:
+      - image: circleci/clojure:lein-2.8.1
+    working_directory: ~/schema
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          # always restore the latest cache
+          key: v1-jars-
+
+      - run: lein deps
+
+      - save_cache:
+          key: v1-jars-{{ checksum "project.clj" }}
+          paths:
+            - ~/.m2
+
+      - restore_cache:
+          key: node-10-13-0
+
+      - run:
+          name: Install node v10.13.0
+          command: |
+            if [ ! -d "${HOME}/node" ]; then
+                cd ${HOME}
+                wget https://nodejs.org/dist/v10.13.0/node-v10.13.0-linux-x64.tar.xz
+                tar xvf node-v10.13.0-linux-x64.tar.xz
+                mv node-v10.13.0-linux-x64 node
+            fi
+
+      - save_cache:
+          key: node-10-13-0
+          paths:
+            - ~/node
+
+      - run: PATH=${HOME}/node/bin:${PATH} lein with-profile +circleci all test

--- a/project.clj
+++ b/project.clj
@@ -4,16 +4,16 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
-                                  [org.clojure/clojurescript "0.0-2760"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
+                                  [org.clojure/clojurescript "1.10.520"]
                                   [org.clojure/tools.nrepl "0.2.5"]
                                   [org.clojure/test.check "0.9.0"]
                                   [potemkin "0.4.1"]]
                    :plugins [[com.keminglabs/cljx "0.6.0" :exclusions [org.clojure/clojure]]
                              [codox "0.8.8"]
-                             [lein-cljsbuild "1.0.5"]
+                             [lein-cljsbuild "1.1.7"]
                              [lein-release/lein-release "1.0.4"]
-                             [com.cemerick/clojurescript.test "0.3.1"]]
+                             [lein-doo "0.1.10"]]
                    :cljx {:builds [{:source-paths ["src/cljx"]
                                     :output-path "target/generated/src/clj"
                                     :rules :clj}
@@ -26,12 +26,12 @@
                                    {:source-paths ["test/cljx"]
                                     :output-path "target/generated/test/cljs"
                                     :rules :cljs}]}}
-             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"] [org.clojure/clojurescript "0.0-3308"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha5"] [org.clojure/clojurescript "0.0-3308"]]}}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"] [org.clojure/clojurescript "1.10.520"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.0"] [org.clojure/clojurescript "1.10.520"]]}}
 
-  :aliases {"all" ["with-profile" "dev:dev,1.8:dev,1.9"]
+  :aliases {"all" ["with-profile" "dev:dev,1.9:dev,1.10"]
             "deploy" ["do" "clean," "cljx" "once," "deploy" "clojars"]
-            "test" ["do" "clean," "cljx" "once," "test," "with-profile" "dev" "cljsbuild" "test"]}
+            "test" ["do" "clean," "cljx" "once," "test," "with-profile" "dev" "doo" "node" "test" "once"]}
 
   :jar-exclusions [#"\.cljx|\.swp|\.swo|\.DS_Store"]
 
@@ -44,32 +44,31 @@
 
   :resource-paths ["target/generated/src/cljs"]
 
-  :test-paths ["target/generated/test/clj" "test/clj"]
+  :test-paths ["target/generated/test/clj" "test/clj" "test/cljs"]
 
-  :cljsbuild {:test-commands {"unit" ["phantomjs" :runner
-                                      "this.literal_js_was_evaluated=true"
-                                      "target/unit-test.js"]
-                              "unit-no-assert" ["phantomjs" :runner
-                                                "this.literal_js_was_evaluated=true"
-                                                "target/unit-test-no-assert.js"]}
-              :builds
-              {:dev {:source-paths ["src/clj" "target/generated/src/cljs"]
-                     :compiler {:output-to "target/main.js"
-                                :optimizations :whitespace
-                                :pretty-print true}}
-               :test {:source-paths ["src/clj" "test/clj"
-                                     "target/generated/src/cljs"
-                                     "target/generated/test/cljs"]
-                      :compiler {:output-to "target/unit-test.js"
-                                 :optimizations :whitespace
-                                 :pretty-print true}}
-               :test-no-assert {:source-paths ["src/clj" "test/clj"
-                                               "target/generated/src/cljs"
-                                               "target/generated/test/cljs"]
-                                :assert false
-                                :compiler {:output-to "target/unit-test-no-assert.js"
-                                           :optimizations :whitespace
-                                           :pretty-print true}}}}
+  :cljsbuild {:builds
+              [{:id "dev"
+                :source-paths ["src/clj" "target/generated/src/cljs"]
+                :compiler {:output-to "target/main.js"
+                           :optimizations :whitespace
+                           :pretty-print true}}
+               {:id "test"
+                :source-paths ["src/clj" "test/clj" "test/cljs"
+                               "target/generated/src/cljs"
+                               "target/generated/test/cljs"]
+                :compiler {:output-to "target/unit-test.js"
+                           :main schema.test-runner
+                           :target :nodejs
+                           :pretty-print true}}
+               {:id "test-no-assert"
+                :source-paths ["src/clj" "test/clj" "test/cljs"
+                               "target/generated/src/cljs"
+                               "target/generated/test/cljs"]
+                :assert false
+                :compiler {:output-to "target/unit-test.js"
+                           :main schema.test-runner
+                           :target :nodejs
+                           :pretty-print true}}]}
 
   :codox {:src-uri-mapping {#"target/generated/src/clj" #(str "src/cljx/" % "x")}
           :src-dir-uri "http://github.com/plumatic/schema/blob/master/"

--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -753,7 +753,7 @@
 
 (clojure.core/defn map-entry-ctor [[k v :as coll]]
   #+clj (clojure.lang.MapEntry. k v)
-  #+cljs (vec coll))
+  #+cljs (cljs.core.MapEntry. k v))
 
 ;; A schema for a single map entry.
 (clojure.core/defrecord MapEntry [key-schema val-schema]

--- a/src/cljx/schema/utils.cljx
+++ b/src/cljx/schema/utils.cljx
@@ -59,9 +59,11 @@
 (defn fn-name
   "A meaningful name for a function that looks like its symbol, if applicable."
   [f]
-  #+cljs (unmunge
-          (or (not-empty (second (re-find #"function ([^\(]*)\(" (str f))))
-              "function"))
+  #+cljs
+  (let [[_ s] (re-matches #"#object\[(.*)\]" (pr-str f))]
+    (if (= "Function" s)
+      "function"
+      (->> s demunge (re-find #"[^/]+$"))))
   #+clj (let [s (.getName (class f))
               slash (.lastIndexOf s "$")
               raw (unmunge

--- a/test/cljs/schema/test_runner.cljs
+++ b/test/cljs/schema/test_runner.cljs
@@ -1,0 +1,14 @@
+(ns schema.test-runner
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [schema.coerce-test]
+            [schema.core-test]
+            [schema.experimental.abstract-map-test]
+            [schema.other-namespace]
+            [schema.test-test]))
+
+(doo-tests
+ 'schema.coerce-test
+ 'schema.core-test
+ 'schema.experimental.abstract-map-test
+ 'schema.other-namespace
+ 'schema.test-test)

--- a/test/cljx/schema/coerce_test.cljx
+++ b/test/cljx/schema/coerce_test.cljx
@@ -1,12 +1,12 @@
 (ns schema.coerce-test
   #+clj (:use clojure.test)
   #+cljs (:use-macros
-          [cemerick.cljs.test :only [is deftest]])
+          [cljs.test :only [is deftest]])
   (:require
    [schema.core :as s]
    [schema.utils :as utils]
    [schema.coerce :as coerce]
-   #+cljs cemerick.cljs.test))
+   #+cljs cljs.test))
 
 ;; s/Num s/Int
 

--- a/test/cljx/schema/core_test.cljx
+++ b/test/cljx/schema/core_test.cljx
@@ -8,7 +8,7 @@
     - (invalid-call! s x) asserts that calling the function throws an error."
   #+clj (:use clojure.test [schema.test-macros :only [valid! invalid! invalid-call!]])
   #+cljs (:use-macros
-          [cemerick.cljs.test :only [is deftest testing are]]
+          [cljs.test :only [is deftest testing are]]
           [schema.test-macros :only [valid! invalid! invalid-call!]])
   #+cljs (:require-macros [schema.macros :as macros])
   (:require
@@ -21,7 +21,7 @@
    [schema.spec.core :as spec]
    [schema.spec.collection :as collection]
    #+clj [schema.macros :as macros]
-   #+cljs cemerick.cljs.test))
+   #+cljs cljs.test))
 
 #+cljs
 (do

--- a/test/cljx/schema/experimental/abstract_map_test.cljx
+++ b/test/cljx/schema/experimental/abstract_map_test.cljx
@@ -1,13 +1,13 @@
 (ns schema.experimental.abstract-map-test
   #+clj (:use clojure.test [schema.test-macros :only [valid! invalid! invalid-call!]])
   #+cljs (:use-macros
-          [cemerick.cljs.test :only [is deftest testing]]
+          [cljs.test :only [is deftest testing]]
           [schema.test-macros :only [valid! invalid! invalid-call!]])
   (:require
    [schema.core :as s]
    [schema.coerce :as coerce]
    [schema.experimental.abstract-map :as abstract-map :include-macros true]
-   #+cljs cemerick.cljs.test))
+   #+cljs cljs.test))
 
 (s/defschema Animal
   (abstract-map/abstract-map-schema


### PR DESCRIPTION
- Upgrade some deps, most notably cljs
  - also changed clojure versions from 1.7,1.8,1.9 to 1.8,1.9,1.10,
    which I believe was necessary due to some other dependency
  - fix some tests that failed due to changes in cljs
    - most notably, the `fn-name` function has been significantly
      changed, and includes a hard-coded check to return
      `"function"` because that's what the test expects; I don't
      *think* there are edge cases there where the string
      `Function` appears some other way, but it's hard to be sure
- switch from clojurescript.test to doo
  - requires adding a test runner file, which is
    the only cljs-only file, so that required adding
    path entries to a couple places
- modernize the cljsbuild config (and modify it to target
  doo)
  - this includes targeting nodejs instead of phantomjs; my
    impression is that phantomjs is no longer maintained, and
    I think node works fine for these purposes
- add circleci config; the code in this commit is currently passing
  on my fork configuration

Things I didn't do, but could:

- attempt to figure out the minimum supported version of cljs
- add more aliases to test more versions of cljs (I upgraded to
  the latest stable version)
- convert to cljc (I have no idea what difficulties there might
  be for this, and I don't think it's a big deal at the moment)