### PR TITLE
Fix "Wrong number of args" warning in cljs.

### DIFF
--- a/src/cljx/schema/core.cljx
+++ b/src/cljx/schema/core.cljx
@@ -753,7 +753,7 @@
 
 (clojure.core/defn map-entry-ctor [[k v :as coll]]
   #+clj (clojure.lang.MapEntry. k v)
-  #+cljs (cljs.core.MapEntry. k v))
+  #+cljs (cljs.core.MapEntry. k v nil))
 
 ;; A schema for a single map entry.
 (clojure.core/defrecord MapEntry [key-schema val-schema]


### PR DESCRIPTION
This PR fixes a "Wrong number of args" warning in cljs. You can see the warning in the attached screenshot (shadow-cljs output):

<img width="611" alt="Screen Shot 2019-07-29 at 5 39 56 PM" src="https://user-images.githubusercontent.com/421618/62090249-5d495100-b229-11e9-8dd4-cb5c9a9c891d.png">

Specifically, the fix calls the MapEntry constructor with the required third __hash arg. The cljs docs specify that the constructor takes 3 arguments: https://cljs.github.io/api/cljs.core/MapEntry

Merging this tiny PR will make our build output a lot less noisy!

Thank you for your good work on this project.