### PR TITLE
Potential fix for schema.utils/fn-name

### DIFF
--- a/src/cljx/schema/utils.cljx
+++ b/src/cljx/schema/utils.cljx
@@ -63,7 +63,7 @@
   (let [[_ s] (re-matches #"#object\[(.*)\]" (pr-str f))]
     (if (= "Function" s)
       "function"
-      (->> s demunge (re-find #"[^/]+$"))))
+      (->> s demunge (re-find #"[^/]+(?:$|(?=/+$))"))))
   #+clj (let [s (.getName (class f))
               slash (.lastIndexOf s "$")
               raw (unmunge

--- a/test/cljs/schema/test_runner.cljs
+++ b/test/cljs/schema/test_runner.cljs
@@ -4,11 +4,13 @@
             [schema.core-test]
             [schema.experimental.abstract-map-test]
             [schema.other-namespace]
-            [schema.test-test]))
+            [schema.test-test]
+            [schema.utils-test]))
 
 (doo-tests
  'schema.coerce-test
  'schema.core-test
  'schema.experimental.abstract-map-test
  'schema.other-namespace
- 'schema.test-test)
+ 'schema.test-test
+ 'schema.utils-test)

--- a/test/cljx/schema/utils_test.cljx
+++ b/test/cljx/schema/utils_test.cljx
@@ -1,0 +1,29 @@
+(ns schema.utils-test
+  #+clj (:use clojure.test)
+  #+cljs (:use-macros
+          [cljs.test :only [are deftest]])
+  (:require
+   [schema.utils :as utils]))
+
+(defn ^:private a-defn-function-with-a-normal-name [a b c d])
+
+(deftest fn-name-test
+  (are [in pattern] (re-matches pattern (utils/fn-name in))
+
+    (fn a-fn-function-with-a-normal-name [x])
+    #+clj #".*/a-fn-function-with-a-normal-name.*"
+    #+cljs #"a-fn-function-with-a-normal-name"
+
+    a-defn-function-with-a-normal-name
+    #+clj #".*/a-defn-function-with-a-normal-name"
+    #+cljs #"a-defn-function-with-a-normal-name"
+
+    ;; regression for issue #416
+    (fn foo$$ [x])
+    #+clj #"schema.utils.*foo.*"
+    #+cljs #"foo"
+
+
+    #(+ 1 2)
+    #+clj #"schema\.utils-test.*"
+    #+cljs #"function"))


### PR DESCRIPTION
This is to address issue #416.

I doubt there is a precise solution for what this function should do,
as, at least in CLJS, it seems like there has to be some ambiguity
introduced by the munging process.

I think we can at least aim for usable output, though.

I didn't make any attempt to figure out what the behavior for `foo$$`
was before commit 2e72125.

There might be more good test cases we can add. The ones I did
required rather different expectations between clj and cljs, since
apparently the two implementations produce rather different output.