### PR TITLE
Support mutually recursive `s/letfn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 1.2.0
+## NEXT
+ * Fix mutually recursive `s/letfn` bindings
+
+## 1.2.0 (`2021-11-03`)
  * **BREAKING** use `cljc` instead of `cljx`, which requires Clojure 1.7 or later. (#425)
 
 ## 1.1.12 (`2019-08-10`)

--- a/project.clj
+++ b/project.clj
@@ -13,10 +13,13 @@
                              [lein-cljsbuild "1.1.7"]
                              [lein-release/lein-release "1.0.4"]
                              [lein-doo "0.1.10"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"] [org.clojure/clojurescript "1.10.520"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"] [org.clojure/clojurescript "1.10.520"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.0"] [org.clojure/clojurescript "1.10.520"]]}}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"] [org.clojure/clojurescript "1.10.879"]]}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"] [org.clojure/clojurescript "1.10.879"]]
+                    :repositories [["sonatype-oss-public" {:url "https://oss.sonatype.org/content/groups/public"}]]}}
 
-  :aliases {"all" ["with-profile" "dev:dev,1.9:dev,1.10"]
+  :aliases {"all" ["with-profile" "dev:dev,1.7:dev,1.9:dev,1.10:dev,1.11"]
             "deploy" ["do" "clean," "deploy" "clojars"]
             "test" ["do" "clean," "test," "with-profile" "dev" "doo" "node" "test" "once"]}
 

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1399,8 +1399,8 @@
   "s/letfn : s/fn :: clojure.core/letfn : clojure.core/fn
   
   Gotchas:
-  - s/fn-schema will only work on direct usages of the bindings
-    in the body. It will not work on intermediate calls between bindings."
+  - s/fn-schema will only work on direct references to the bindings
+    inside the body. It will not work on intermediate calls between bindings."
   [fnspecs & body]
   (let [{:keys [outer-bindings
                 fnspecs

--- a/test/cljc/schema/core_test.cljc
+++ b/test/cljc/schema/core_test.cljc
@@ -1211,9 +1211,8 @@
   (is (every? s/fn-schema
               (s/letfn
                 [(even :- s/Int [x :- s/Int] (if (zero? x) true (odd (dec x))))
-                 (odd :- s/Int [x :- s/Int] (if (zero? x) false (even (dec x))))
-                 (getter [] [getter even odd])]
-                (conj (getter) even odd getter)))))
+                 (odd :- s/Int [x :- s/Int] (if (zero? x) false (even (dec x))))]
+                [even odd]))))
 
 (deftest error-letfn-test
   (s/with-fn-validation


### PR DESCRIPTION
I noticed `s/letfn` is unlike `letfn` in that it does not support mutually recursive bindings.