### PR TITLE
Fix `s/fn` performance issues in Clojure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml
 *.asc
 /doc/
 .nrepl-port
+.cpcache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
  * Fix mutually recursive `s/letfn` bindings
+ * Fix `s/fn` perf caveats in Clojure by avoiding wrappers
 
 ## 1.2.0 (`2021-11-03`)
  * **BREAKING** use `cljc` instead of `cljx`, which requires Clojure 1.7 or later. (#425)

--- a/project.clj
+++ b/project.clj
@@ -13,15 +13,14 @@
                              [lein-cljsbuild "1.1.7"]
                              [lein-release/lein-release "1.0.4"]
                              [lein-doo "0.1.10"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"] [org.clojure/clojurescript "1.10.520"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"] [org.clojure/clojurescript "1.10.520"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"] [org.clojure/clojurescript "1.10.879"]]}
              :1.11 {:dependencies [[org.clojure/clojure "1.11.0-master-SNAPSHOT"] [org.clojure/clojurescript "1.10.879"]]
                     :repositories [["sonatype-oss-public" {:url "https://oss.sonatype.org/content/groups/public"}]]}}
 
-  :aliases {"all" ["with-profile" "dev:dev,1.7:dev,1.9:dev,1.10:dev,1.11"]
+  :aliases {"all" ["with-profile" "+dev:+1.9:+1.10:+1.11"]
             "deploy" ["do" "clean," "deploy" "clojars"]
-            "test" ["do" "clean," "test," "with-profile" "dev" "doo" "node" "test" "once"]}
+            "test" ["do" "clean," "test," "doo" "node" "test" "once"]}
 
   :jar-exclusions [#"\.swp|\.swo|\.DS_Store"]
 


### PR DESCRIPTION
While trying to implement `s/defprotocol`, I needed the following invariant to hold in Clojure to access [__methodImplCache](https://github.com/clojure/clojure/blob/b8132f92f3c3862aa6cdd8a72e4e74802a63f673/src/clj/clojure/core_deftype.clj#L609):

```clojure
(let [f (s/fn this [] this)]
  (identical? f (f)))
```

The fix I chose was to use `^{:schema schema} (fn ...)` instead of `(with-meta (fn ...) {:schema schema})`. I believe this also fixed all the documented performance caveats for `s/fn` in Clojure as it means wrappers are eliminated.

The perf characteristics for CLJS seem unchanged (still uses the wrapper). I worked around [CLJS-968](https://clojure.atlassian.net/browse/CLJS-968) by placing the function evaluation in non-tail position. I decided working around this issue was better than using `macros/if-cljs` (which I treat as a last resort).

I also moved a test, please ignore whitespace changes when reviewing.