### PR TITLE
s/constructor/konstructor/ to avoid cljs edge case

### DIFF
--- a/src/clj/schema/experimental/generators.clj
+++ b/src/clj/schema/experimental/generators.clj
@@ -80,7 +80,7 @@
   (composite-generator [s params]
     (generators/such-that
      (complement (.-pre ^schema.spec.collection.CollectionSpec s))
-     (generators/fmap (:constructor s) (elements-generator (:elements s) params))))
+     (generators/fmap (:konstructor s) (elements-generator (:elements s) params))))
 
   schema.spec.leaf.LeafSpec
   (composite-generator [s params]

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1016,7 +1016,7 @@
        (if-let [evf (:extra-validator-fn this)]
          (some-fn p (spec/precondition this evf #(list 'passes-extra-validation? %)))
          p))
-     (:constructor (meta this))
+     (:konstructor (meta this))
      (map-elements schema)
      (map-error)))
   (explain [this]
@@ -1027,7 +1027,7 @@
 (clojure.core/defn record* [klass schema map-constructor]
   #?(:clj (macros/assert! (class? klass) "Expected record class, got %s" (utils/type-of klass)))
   (macros/assert! (map? schema) "Expected map, got %s" (utils/type-of schema))
-  (with-meta (Record. klass schema) {:constructor map-constructor}))
+  (with-meta (Record. klass schema) {:konstructor map-constructor}))
 
 #?(:clj
 (defmacro record

--- a/src/cljc/schema/spec/collection.cljc
+++ b/src/cljc/schema/spec/collection.cljc
@@ -67,11 +67,11 @@
         (assert (#{::remaining ::optional} (first elt)))
         (mapcat subschemas (next elt)))))
 
-(defrecord CollectionSpec [pre constructor elements on-error]
+(defrecord CollectionSpec [pre konstructor elements on-error]
   spec/CoreSpec
   (subschemas [this] (mapcat subschemas elements))
   (checker [this params]
-    (let [constructor (if (:return-walked? params) constructor (fn [_] nil))
+    (let [konstructor (if (:return-walked? params) konstructor (fn [_] nil))
           t (sequence-transformer elements params (fn [_ x] x))]
       (fn [x]
         (or (pre x)
@@ -80,7 +80,7 @@
                   res #?(:clj res :cljs @res)]
               (if (or (seq remaining) (has-error? res))
                 (utils/error (on-error x res remaining))
-                (constructor res))))))))
+                (konstructor res))))))))
 
 
 (defn collection-spec
@@ -100,7 +100,7 @@
    the user must ensure that the parser enforces the desired semantics, which
    should match the structure of the spec for proper generation."
   [pre ;- spec/Precondition
-   constructor ;- (s/=> s/Any [(s/named s/Any 'checked-value)])
+   konstructor ;- (s/=> s/Any [(s/named s/Any 'checked-value)])
    elements ;- [(s/cond-pre
    ;;            {:schema (s/protocol Schema)
    ;;             :parser (s/=> s/Any (s/=> s/Any s/Any) s/Any) ; takes [item-fn coll], calls item-fn on matching items, returns remaining.
@@ -109,7 +109,7 @@
    ;;          where the last element can optionally be a [::remaining schema]
    on-error ;- (=> s/Any (s/named s/Any 'value) [(s/named s/Any 'checked-element)] [(s/named s/Any 'unmatched-element)])
    ]
-  (->CollectionSpec pre constructor elements on-error))
+  (->CollectionSpec pre konstructor elements on-error))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/cljc/schema/core_test.cljc
+++ b/test/cljc/schema/core_test.cljc
@@ -787,7 +787,7 @@
 #?(:clj (s/defrecord Nested [^Bar4 b ^LongOrString c p :- (s/protocol PProtocol)]))
 (s/defrecord NestedExplicit [b :- Bar4 c :- LongOrString p :- (s/protocol PProtocol)])
 
-(defn test-fancier-defrecord-schema [klass constructor]
+(defn test-fancier-defrecord-schema [klass konstructor]
   (let [bar1 (Bar. 1 "a")
         bar2 (Bar2. 1 "a")]
     (is (= (utils/class-schema klass)
@@ -796,12 +796,12 @@
             {:b Bar4
              :c LongOrString
              :p (s/protocol PProtocol)}
-            constructor)))
-    (valid! klass (constructor {:b (Bar4. [1] {}) :c 1 :p bar2}))
-    (valid! klass (constructor {:b (Bar4. [1] {}) :c "hi" :p bar2}))
-    (invalid! klass (constructor {:b (Bar4. [1] {}) :c "hi" :p bar1}))
-    (invalid! klass (constructor {:b (Bar4. [1] {:foo :bar}) :c 1 :p bar2}))
-    (invalid! klass (constructor {:b nil :c "hi" :p bar2}))))
+            konstructor)))
+    (valid! klass (konstructor {:b (Bar4. [1] {}) :c 1 :p bar2}))
+    (valid! klass (konstructor {:b (Bar4. [1] {}) :c "hi" :p bar2}))
+    (invalid! klass (konstructor {:b (Bar4. [1] {}) :c "hi" :p bar1}))
+    (invalid! klass (konstructor {:b (Bar4. [1] {:foo :bar}) :c 1 :p bar2}))
+    (invalid! klass (konstructor {:b nil :c "hi" :p bar2}))))
 
 (deftest fancier-defrecord-schema-test
   #?(:clj (test-fancier-defrecord-schema Nested map->Nested))


### PR DESCRIPTION
Replace constructor to konstructor due to some issues with cljs

See plumatic/schema-generators#22