### PR TITLE
Babashka support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,6 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - name: Download babashka
-        run: bash <(curl https://raw.githubusercontent.com/babashka/babashka/master/install) --version 0.8.3-SNAPSHOT --dir .
+        run: bash <(curl https://raw.githubusercontent.com/babashka/babashka/master/install) --dir .
       - name: Run Babashka tests
         run: ./bb test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           distribution: 'temurin'
           java-version: 11
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.5
+        uses: DeLaGuardo/setup-clojure@5.1
         with:
           lein: ${{ env.LEIN_VERSION }}
       - name: Run trojansourcedetector
@@ -57,16 +57,16 @@ jobs:
           distribution: 'temurin'
           java-version: 11
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.5
+        uses: DeLaGuardo/setup-clojure@5.1
         with:
           lein: ${{ env.LEIN_VERSION }}
       - name: Run Eastwood
         run: lein eastwood
-  test:
+  test-jvm:
     needs: setup
     strategy:
       matrix:
-        java: ['8', '11', '17']
+        java: ['8', '11', '17', '18']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -86,8 +86,23 @@ jobs:
         with:
           node-version: '17.7.2'
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@3.5
+        uses: DeLaGuardo/setup-clojure@5.1
         with:
           lein: ${{ env.LEIN_VERSION }}
-      - name: Run tests
+      - name: Run JVM tests
         run: lein all test
+  test-bb:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Prepare java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 17
+      - name: Download babashka
+        run: bash <(curl https://raw.githubusercontent.com/babashka/babashka/master/install) --version 0.8.3-SNAPSHOT --dir .
+      - name: Run Babashka tests
+        run: ./bb test

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml
 .nrepl-port
 .cpcache/
 .eastwood
+bb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## NEXT
+ * Babashka support
+ * CLJS: Add pretty `pr-str` for schemas
 
 ## 1.2.1 (`2022-04-28`)
  * Fix mutually recursive `s/letfn` bindings

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ If you make something new, please feel free to PR to add it here!
 
 ## Supported Clojure versions
 
-Schema is currently supported on Clojure 1.8 onwards and the latest version of ClojureScript.
+Schema is currently supported on Clojure 1.8 onwards, [Babashka](https://github.com/babashka/babashka) 0.8.4 onwards, and the latest version of ClojureScript.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ If you make something new, please feel free to PR to add it here!
 
 ## Supported Clojure versions
 
-Schema is currently supported on Clojure 1.8 onwards, [Babashka](https://github.com/babashka/babashka) 0.8.4 onwards, and the latest version of ClojureScript.
+Schema is currently supported on Clojure 1.8 onwards, [Babashka](https://github.com/babashka/babashka) 0.8.156 onwards, and the latest version of ClojureScript.
 
 ## License
 

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,13 @@
+{:paths ["src/clj" "src/cljc" "test/clj" "test/cljc" "test/bb"]
+ ;:deps {org.clojure/test.check {:mvn/version "1.1.1"}}
+ :tasks
+ {:requires ([babashka.fs :as fs]
+             [babashka.process :as p :refer [process]]
+             [babashka.wait :as wait])
+  nrepl (let [port (with-open [sock (java.net.ServerSocket. 0)] (.getLocalPort sock))
+              proc (process (str "bb nrepl-server " port) {:inherit true})]
+          (wait/wait-for-port "localhost" port)
+          (spit ".nrepl-port" port)
+          (fs/delete-on-exit ".nrepl-port")
+          (deref proc))
+  test (require 'schema.bb-test-runner)}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,2 @@
-{:paths ["src/clj" "src/cljc"]}
+{:paths ["src/clj" "src/cljc"]
+ :aliases {:test {:extra-paths ["test/clj" "test/cljc" "test/cljs"]}}}

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                                   [potemkin "0.4.1"]]
                    :eastwood {:exclude-namespaces []
                               :exclude-linters [:def-in-def :local-shadows-var :constant-test :suspicious-expression :deprecations
-                                                :unused-meta-on-macro :wrong-tag]}
+                                                :unused-meta-on-macro :wrong-tag :unused-ret-vals]}
                    :plugins [[codox "0.8.8"]
                              [lein-cljsbuild "1.1.7"]
                              [lein-release/lein-release "1.0.4"]

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -220,8 +220,6 @@
      (or (:always-validate fn-meta)
          *assert*))))
 
-(def ^:dynamic *ufv-sym* 'ufv__) ;; dynamic for backwards compat
-
 (defn process-fn-arity
   "Process a single (bind & body) form, producing an output tag, schema-form,
    and arity-form which has asserts for validation purposes added that are
@@ -230,68 +228,72 @@
    schema-bindings are bindings to lift eval outwards, so we don't build the schema
    every time we do the validation.
   
-  Bind *ufv-sym* for control over ufv__ name."
-  [env fn-name output-schema-sym bind-meta [bind & body]]
-  (assert! (vector? bind) "Got non-vector binding form %s" bind)
-  (when-let [bad-meta (seq (filter (or (meta bind) {}) [:tag :s? :s :schema]))]
-    (throw (RuntimeException. (str "Meta not supported on bindings, put on fn name" (vec bad-meta)))))
-  (let [original-arglist bind
-        bind (with-meta (process-arrow-schematized-args env bind) bind-meta)
-        [regular-args rest-arg] (split-rest-arg env bind)
-        input-schema-sym (gensym "input-schema")
-        input-checker-sym (gensym "input-checker")
-        output-checker-sym (gensym "output-checker")
-        compile-validation (compile-fn-validation? env fn-name)
-        ufv-sym *ufv-sym*]
-    {:schema-binding [input-schema-sym (input-schema-form regular-args rest-arg)]
-     :more-bindings (when compile-validation
-                      [input-checker-sym `(delay (schema.core/checker ~input-schema-sym))
-                       output-checker-sym `(delay (schema.core/checker ~output-schema-sym))])
-     :arglist bind
-     :raw-arglist original-arglist
-     :arity-form (if compile-validation
-                   (let [bind-syms (vec (repeatedly (count regular-args) gensym))
-                         rest-sym (when rest-arg (gensym "rest"))
-                         metad-bind-syms (with-meta (mapv #(with-meta %1 (meta %2)) bind-syms bind) bind-meta)]
-                     (list
-                      (if rest-arg
-                        (into metad-bind-syms ['& rest-sym])
-                        metad-bind-syms)
-                      `(let [validate# ~(if (:always-validate (meta fn-name))
-                                          `true
-                                          `(if-cljs (deref ~ufv-sym)
-                                                    (if-bb (deref ~ufv-sym) (.get ~ufv-sym))))]
-                         (when validate#
-                           (let [args# ~(if rest-arg
-                                          `(list* ~@bind-syms ~rest-sym)
-                                          bind-syms)]
-                             (if schema.core/fn-validator
-                               (schema.core/fn-validator :input
-                                                         '~fn-name
-                                                         ~input-schema-sym
-                                                         @~input-checker-sym
-                                                         args#)
-                               (when-let [error# (@~input-checker-sym args#)]
-                                 (error! (utils/format* "Input to %s does not match schema: \n\n\t \033[0;33m  %s \033[0m \n\n"
-                                                        '~fn-name (pr-str error#))
-                                         {:schema ~input-schema-sym :value args# :error error#})))))
-                         (let [o# (loop ~(into (vec (interleave (map #(with-meta % {}) bind) bind-syms))
-                                               (when rest-arg [rest-arg rest-sym]))
-                                    ~@(apply-prepost-conditions body))]
+  :ufv-sym should name a local binding bound to `schema.utils/use-fn-validation`.
+  
+  5-args arity is deprecated."
+  ([env fn-name output-schema-sym bind-meta arity-form]
+   (process-fn-arity {:env env :fn-name fn-name :output-schema-sym output-schema-sym
+                      :bind-meta bind-meta :arity-form arity-form :ufv-sym 'ufv__}))
+  ([{[bind & body] :arity-form :keys [env fn-name output-schema-sym bind-meta ufv-sym]}]
+   (assert! (vector? bind) "Got non-vector binding form %s" bind)
+   (when-let [bad-meta (seq (filter (or (meta bind) {}) [:tag :s? :s :schema]))]
+     (throw (RuntimeException. (str "Meta not supported on bindings, put on fn name" (vec bad-meta)))))
+   (let [original-arglist bind
+         bind (with-meta (process-arrow-schematized-args env bind) bind-meta)
+         [regular-args rest-arg] (split-rest-arg env bind)
+         input-schema-sym (gensym "input-schema")
+         input-checker-sym (gensym "input-checker")
+         output-checker-sym (gensym "output-checker")
+         compile-validation (compile-fn-validation? env fn-name)]
+     {:schema-binding [input-schema-sym (input-schema-form regular-args rest-arg)]
+      :more-bindings (when compile-validation
+                       [input-checker-sym `(delay (schema.core/checker ~input-schema-sym))
+                        output-checker-sym `(delay (schema.core/checker ~output-schema-sym))])
+      :arglist bind
+      :raw-arglist original-arglist
+      :arity-form (if compile-validation
+                    (let [bind-syms (vec (repeatedly (count regular-args) gensym))
+                          rest-sym (when rest-arg (gensym "rest"))
+                          metad-bind-syms (with-meta (mapv #(with-meta %1 (meta %2)) bind-syms bind) bind-meta)]
+                      (list
+                        (if rest-arg
+                          (into metad-bind-syms ['& rest-sym])
+                          metad-bind-syms)
+                        `(let [validate# ~(if (:always-validate (meta fn-name))
+                                            `true
+                                            `(if-cljs (deref ~ufv-sym)
+                                                      (if-bb (deref ~ufv-sym) (.get ~ufv-sym))))]
                            (when validate#
-                             (if schema.core/fn-validator
-                               (schema.core/fn-validator :output
-                                                         '~fn-name
-                                                         ~output-schema-sym
-                                                         @~output-checker-sym
-                                                         o#)
-                               (when-let [error# (@~output-checker-sym o#)]
-                                 (error! (utils/format* "Output of %s does not match schema: \n\n\t \033[0;33m  %s \033[0m \n\n"
-                                                        '~fn-name (pr-str error#))
-                                         {:schema ~output-schema-sym :value o# :error error#}))))
-                           o#))))
-                   (cons (into regular-args (when rest-arg ['& rest-arg]))
-                         body))}))
+                             (let [args# ~(if rest-arg
+                                            `(list* ~@bind-syms ~rest-sym)
+                                            bind-syms)]
+                               (if schema.core/fn-validator
+                                 (schema.core/fn-validator :input
+                                                           '~fn-name
+                                                           ~input-schema-sym
+                                                           @~input-checker-sym
+                                                           args#)
+                                 (when-let [error# (@~input-checker-sym args#)]
+                                   (error! (utils/format* "Input to %s does not match schema: \n\n\t \033[0;33m  %s \033[0m \n\n"
+                                                          '~fn-name (pr-str error#))
+                                           {:schema ~input-schema-sym :value args# :error error#})))))
+                           (let [o# (loop ~(into (vec (interleave (map #(with-meta % {}) bind) bind-syms))
+                                                 (when rest-arg [rest-arg rest-sym]))
+                                      ~@(apply-prepost-conditions body))]
+                             (when validate#
+                               (if schema.core/fn-validator
+                                 (schema.core/fn-validator :output
+                                                           '~fn-name
+                                                           ~output-schema-sym
+                                                           @~output-checker-sym
+                                                           o#)
+                                 (when-let [error# (@~output-checker-sym o#)]
+                                   (error! (utils/format* "Output of %s does not match schema: \n\n\t \033[0;33m  %s \033[0m \n\n"
+                                                          '~fn-name (pr-str error#))
+                                           {:schema ~output-schema-sym :value o# :error error#}))))
+                             o#))))
+                    (cons (into regular-args (when rest-arg ['& rest-arg]))
+                          body))})))
 
 (defn process-fn-
   "Process the fn args into a final tag proposal, schema form, schema bindings, and fn form"
@@ -304,8 +306,8 @@
                           {:tag t}))
                       {})
         ufv-sym (gensym "ufv")
-        processed-arities (map #(binding [*ufv-sym* ufv-sym]
-                                  (process-fn-arity env name output-schema-sym bind-meta %))
+        processed-arities (map #(process-fn-arity {:env env :fn-name name :output-schema-sym output-schema-sym
+                                                   :bind-meta bind-meta :arity-form % :ufv-sym ufv-sym})
                                (if (vector? (first fn-body))
                                  [fn-body]
                                  fn-body))

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -118,16 +118,20 @@
      user> (s/explain {:a s/Keyword :b [s/Int]} )
      {:a Keyword, :b [Int]}"))
 
-;; Schemas print as their explains
 #?(:clj
-(do (clojure.core/defmethod print-method schema.core.Schema [s writer]
-      (print-method (explain s) writer))
-    (clojure.core/defmethod pprint/simple-dispatch schema.core.Schema [s]
-      (pprint/write-out (explain s)))
-    (doseq [m [print-method pprint/simple-dispatch]]
-      (prefer-method m schema.core.Schema clojure.lang.IRecord)
-      (prefer-method m schema.core.Schema java.util.Map)
-      (prefer-method m schema.core.Schema clojure.lang.IPersistentMap))))
+(clojure.core/defn register-schema-print-as-explain [t]
+  (clojure.core/defmethod print-method t [s writer]
+    (print-method (explain s) writer))
+  (clojure.core/defmethod pprint/simple-dispatch t [s]
+    (pprint/write-out (explain s)))))
+
+;; macros/defrecord-schema implements print methods in bb/cljs
+#?(:bb nil
+   :clj (do (register-schema-print-as-explain schema.core.Schema)
+            (doseq [m [print-method pprint/simple-dispatch]]
+              (prefer-method m schema.core.Schema clojure.lang.IRecord)
+              (prefer-method m schema.core.Schema java.util.Map)
+              (prefer-method m schema.core.Schema clojure.lang.IPersistentMap))))
 
 (clojure.core/defn checker
   "Compile an efficient checker for schema, which returns nil for valid values and
@@ -167,7 +171,8 @@
 ;;; Platform-specific leaf Schemas
 
 ;; On the JVM, a Class itself is a schema. In JS, we treat functions as prototypes so any
-;; function prototype checks objects for compatibility.
+;; function prototype checks objects for compatibility. In BB, defrecord classes can also be
+;; symbols.
 
 (clojure.core/defn instance-precondition [s klass]
   (spec/precondition
@@ -178,25 +183,34 @@
                       (js* "~{} instanceof ~{}" % klass))))
    #(list 'instance? klass %)))
 
+(defn- -class-spec [this]
+  (let [pre (instance-precondition this this)]
+    (if-let [class-schema (utils/class-schema this)]
+      (variant/variant-spec pre [{:schema class-schema}])
+      (leaf/leaf-spec pre))))
+
+(defn- -class-explain [this]
+  (if-let [more-schema (utils/class-schema this)]
+    (explain more-schema)
+    (condp = this
+      #?(:clj java.lang.String :cljs nil) 'Str
+      #?(:clj java.lang.Boolean :cljs js/Boolean) 'Bool
+      #?(:clj java.lang.Number :cljs js/Number) 'Num
+      #?(:clj java.util.regex.Pattern :cljs nil) 'Regex
+      #?(:clj java.util.Date :cljs js/Date) 'Inst
+      #?(:clj java.util.UUID :cljs cljs.core/UUID) 'Uuid
+      #?(:clj (or #?(:bb (when (symbol? this) this))
+                  (symbol (.getName ^Class this)))
+         :cljs this))))
+
 (extend-protocol Schema
   #?(:clj Class
      :cljs function)
-  (spec [this]
-    (let [pre (instance-precondition this this)]
-      (if-let [class-schema (utils/class-schema this)]
-        (variant/variant-spec pre [{:schema class-schema}])
-        (leaf/leaf-spec pre))))
-  (explain [this]
-    (if-let [more-schema (utils/class-schema this)]
-      (explain more-schema)
-      (condp = this
-        #?(:clj java.lang.String :cljs nil) 'Str
-        #?(:clj java.lang.Boolean :cljs js/Boolean) 'Bool
-        #?(:clj java.lang.Number :cljs js/Number) 'Num
-        #?(:clj java.util.regex.Pattern :cljs nil) 'Regex
-        #?(:clj java.util.Date :cljs js/Date) 'Inst
-        #?(:clj java.util.UUID :cljs cljs.core/UUID) 'Uuid
-        #?(:clj (symbol (.getName ^Class this)) :cljs this)))))
+  (spec [this] (-class-spec this))
+  (explain [this] (-class-explain this))
+  #?@(:bb [clojure.lang.Symbol
+           (spec [this] (-class-spec this))
+           (explain [this] (-class-explain this))]))
 
 
 ;; On the JVM, the primitive coercion functions (double, long, etc)
@@ -236,7 +250,7 @@
 
 ;;; Any matches anything (including nil)
 
-(clojure.core/defrecord AnythingSchema [_]
+(macros/defrecord-schema AnythingSchema [_]
   ;; _ is to work around bug in Clojure where eval-ing defrecord with no fields
   ;; loses type info, which makes this unusable in schema-fn.
   ;; http://dev.clojure.org/jira/browse/CLJ-1093
@@ -251,7 +265,7 @@
 
 ;;; eq (to a single allowed value)
 
-(clojure.core/defrecord EqSchema [v]
+(macros/defrecord-schema EqSchema [v]
   Schema
   (spec [this] (leaf/leaf-spec (spec/precondition this #(= v %) #(list '= v %))))
   (explain [this] (list 'eq v)))
@@ -264,7 +278,7 @@
 
 ;;; isa (a child of parent)
 
-(clojure.core/defrecord Isa [h parent]
+(macros/defrecord-schema Isa [h parent]
   Schema
   (spec [this] (leaf/leaf-spec (spec/precondition this
                                                   #(if h
@@ -283,7 +297,7 @@
 
 ;;; enum (in a set of allowed values)
 
-(clojure.core/defrecord EnumSchema [vs]
+(macros/defrecord-schema EnumSchema [vs]
   Schema
   (spec [this] (leaf/leaf-spec (spec/precondition this #(contains? vs %) #(list vs %))))
   (explain [this] (cons 'enum vs)))
@@ -296,7 +310,7 @@
 
 ;;; pred (matches all values for which p? returns truthy)
 
-(clojure.core/defrecord Predicate [p? pred-name]
+(macros/defrecord-schema Predicate [p? pred-name]
   Schema
   (spec [this] (leaf/leaf-spec (spec/precondition this p? #(list pred-name %))))
   (explain [this]
@@ -323,22 +337,22 @@
 
 ;; In cljs, satisfies? is a macro so we must precompile (partial satisfies? p)
 ;; and put it in metadata of the record so that equality is preserved, along with the name.
-(clojure.core/defrecord Protocol [p]
+(macros/defrecord-schema Protocol [p]
   Schema
   (spec [this]
     (leaf/leaf-spec
      (spec/precondition
       this
-      #((:proto-pred (meta this)) %)
+      (:proto-pred (meta this))
       #(list 'satisfies? (protocol-name this) %))))
   (explain [this] (list 'protocol (protocol-name this))))
 
 ;; The cljs version is macros/protocol by necessity, since cljs `satisfies?` is a macro.
 #?(:clj
 (defmacro protocol
-  "A value that must satsify? protocol p.
+  "A value that must satisfy? protocol p.
 
-   Internaly, we must make sure not to capture the value of the protocol at
+   Internally, we must make sure not to capture the value of the protocol at
    schema creation time, since that's impossible in cljs and breaks later
    extends in Clojure.
 
@@ -415,7 +429,7 @@
 
 ;;; maybe (nil)
 
-(clojure.core/defrecord Maybe [schema]
+(macros/defrecord-schema Maybe [schema]
   Schema
   (spec [this]
     (variant/variant-spec
@@ -432,7 +446,7 @@
 
 ;;; named (schema elements)
 
-(clojure.core/defrecord NamedSchema [schema name]
+(macros/defrecord-schema NamedSchema [schema name]
   Schema
   (spec [this]
     (variant/variant-spec
@@ -448,7 +462,7 @@
 
 ;;; either (satisfies this schema or that one)
 
-(clojure.core/defrecord Either [schemas]
+(macros/defrecord-schema Either [schemas]
   Schema
   (spec [this]
     (variant/variant-spec
@@ -475,7 +489,7 @@
 
 ;;; conditional (choice of schema, based on predicates on the value)
 
-(clojure.core/defrecord ConditionalSchema [preds-and-schemas error-symbol]
+(macros/defrecord-schema ConditionalSchema [preds-and-schemas error-symbol]
   Schema
   (spec [this]
     (variant/variant-spec
@@ -546,7 +560,7 @@
   (precondition [this]
     (complement (.-pre ^schema.spec.collection.CollectionSpec this))))
 
-(clojure.core/defrecord CondPre [schemas]
+(macros/defrecord-schema CondPre [schemas]
   Schema
   (spec [this]
     (variant/variant-spec
@@ -581,7 +595,7 @@
 
 ;; constrained (post-condition on schema)
 
-(clojure.core/defrecord Constrained [schema postcondition post-name]
+(macros/defrecord-schema Constrained [schema postcondition post-name]
   Schema
   (spec [this]
     (variant/variant-spec
@@ -605,7 +619,7 @@
 
 ;;; both (satisfies this schema and that one)
 
-(clojure.core/defrecord Both [schemas]
+(macros/defrecord-schema Both [schemas]
   Schema
   (spec [this] this)
   (explain [this] (cons 'both (map explain schemas)))
@@ -651,7 +665,7 @@
                     :cljs ns)
                  "/" name))))
 
-(clojure.core/defrecord Recursive [derefable]
+(macros/defrecord-schema Recursive [derefable]
   Schema
   (spec [this] (variant/variant-spec spec/+no-precondition+ [{:schema @derefable}]))
   (explain [this]
@@ -683,7 +697,7 @@
   #?(:clj (instance? clojure.lang.Atom x)
      :cljs (satisfies? IAtom x)))
 
-(clojure.core/defrecord Atomic [schema]
+(macros/defrecord-schema Atomic [schema]
   Schema
   (spec [this]
     (collection/collection-spec
@@ -761,7 +775,7 @@
      :cljs (cljs.core.MapEntry. k v nil)))
 
 ;; A schema for a single map entry.
-(clojure.core/defrecord MapEntry [key-schema val-schema]
+(macros/defrecord-schema MapEntry [key-schema val-schema]
   Schema
   (spec [this]
     (collection/collection-spec
@@ -891,7 +905,7 @@
       :cljs cljs.core/PersistentQueue.EMPTY)
    col))
 
-(clojure.core/defrecord Queue [schema]
+(macros/defrecord-schema Queue [schema]
   Schema
   (spec [this]
     (collection/collection-spec
@@ -1008,7 +1022,7 @@
 ;; also satisfy a map schema.  An optional :extra-validator-fn can also be attached to do
 ;; additional validation.
 
-(clojure.core/defrecord Record [klass schema]
+(macros/defrecord-schema Record [klass schema]
   Schema
   (spec [this]
     (collection/collection-spec
@@ -1020,12 +1034,14 @@
      (map-elements schema)
      (map-error)))
   (explain [this]
-    (list 'record #?(:clj (symbol (.getName ^Class klass))
+    (list 'record #?(:clj (or #?(:bb (when (symbol? klass) klass))
+                              (symbol (.getName ^Class klass)))
                      :cljs (symbol (pr-str klass)))
           (explain schema))))
 
 (clojure.core/defn record* [klass schema map-constructor]
-  #?(:clj (macros/assert! (class? klass) "Expected record class, got %s" (utils/type-of klass)))
+  #?(:bb (macros/assert! (or (class? klass) (symbol? klass)) "Expected record class or symbol, got %s" (utils/type-of klass))
+     :clj (macros/assert! (class? klass) "Expected record class, got %s" (utils/type-of klass)))
   (macros/assert! (map? schema) "Expected map, got %s" (utils/type-of schema))
   (with-meta (Record. klass schema) {:konstructor map-constructor}))
 
@@ -1037,11 +1053,15 @@
    not pass one, an attempt is made to find the corresponding function
    (but this may fail in exotic circumstances)."
   ([klass schema]
+   (let [map-ctor-var (let [bits (str/split (name klass) #"/")]
+                        (symbol (str/join "/" (concat (butlast bits) [(str "map->" (last bits))]))))
+         map-ctor-mth (symbol (str (name klass) "/create"))]
      `(record ~klass ~schema
               (macros/if-cljs
-               ~(let [bits (str/split (name klass) #"/")]
-                  (symbol (str/join "/" (concat (butlast bits) [(str "map->" (last bits))]))))
-               #(~(symbol (str (name klass) "/create")) %))))
+                ~map-ctor-var
+                (macros/if-bb
+                  ~map-ctor-var
+                  #(~map-ctor-mth %))))))
   ([klass schema map-constructor]
      `(record* ~klass ~schema #(~map-constructor (into {} %))))))
 
@@ -1061,7 +1081,7 @@
             (when (seq more)
               ['& (mapv explain more)]))))
 
-(clojure.core/defrecord FnSchema [output-schema input-schemas] ;; input-schemas sorted by arity
+(macros/defrecord-schema FnSchema [output-schema input-schemas] ;; input-schemas sorted by arity
   Schema
   (spec [this] (leaf/leaf-spec (spec/simple-precondition this ifn?)))
   (explain [this]
@@ -1198,13 +1218,15 @@
 (clojure.core/defn fn-validation?
   "Get the current global schema validation setting."
   []
-  #?(:clj (.get ^java.util.concurrent.atomic.AtomicReference utils/use-fn-validation)
+  #?(:bb @utils/use-fn-validation
+     :clj (.get ^java.util.concurrent.atomic.AtomicReference utils/use-fn-validation)
      :cljs @utils/use-fn-validation))
 
 (clojure.core/defn set-fn-validation!
   "Globally turn on (or off) schema validation for all s/fn and s/defn instances."
   [on?]
-  #?(:clj (.set ^java.util.concurrent.atomic.AtomicReference utils/use-fn-validation on?)
+  #?(:bb (reset! utils/use-fn-validation on?)
+     :clj (.set ^java.util.concurrent.atomic.AtomicReference utils/use-fn-validation on?)
      :cljs (reset! utils/use-fn-validation on?)))
 
 #?(:clj
@@ -1392,15 +1414,18 @@
 
      (s/defmethod ^:always-validate mymultifun :a-dispatch-value [x y] (* x y))"
   [multifn dispatch-val & fn-tail]
-  `(macros/if-cljs
-    (cljs.core/-add-method
-     ~(with-meta multifn {:tag 'cljs.core/MultiFn})
-     ~dispatch-val
-     (fn ~(with-meta (gensym (str (name multifn) "__")) (meta multifn)) ~@fn-tail))
-    (. ~(with-meta multifn {:tag 'clojure.lang.MultiFn})
-       addMethod
-       ~dispatch-val
-       (fn ~(with-meta (gensym (str (name multifn) "__")) (meta multifn)) ~@fn-tail)))))
+  (let [methodfn `(fn ~(with-meta (gensym (str (name multifn) "__")) (meta multifn)) ~@fn-tail)]
+    `(macros/if-cljs
+       (cljs.core/-add-method
+         ~(with-meta multifn {:tag 'cljs.core/MultiFn})
+         ~dispatch-val
+         ~methodfn)
+       ~#?(:bb `(let [methodfn# ~methodfn]
+                  (clojure.core/defmethod ~multifn ~dispatch-val [& args#] (apply methodfn# args#)))
+           :default `(. ~(with-meta multifn {:tag 'clojure.lang.MultiFn})
+                        addMethod
+                        ~dispatch-val
+                        ~methodfn))))))
 
 #?(:clj
 (defmacro letfn

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1042,8 +1042,7 @@
           (explain schema))))
 
 (clojure.core/defn record* [klass schema map-constructor]
-  #?(:bb (macros/assert! (or (class? klass) (instance? sci.lang.Type klass)) "Expected record class or symbol, got %s" (utils/type-of klass))
-     :clj (macros/assert! (class? klass) "Expected record class, got %s" (utils/type-of klass)))
+  (macros/assert! (or (class? klass) #?(:bb (instance? sci.lang.Type klass))) "Expected record class, got %s" (utils/type-of klass))
   (macros/assert! (map? schema) "Expected map, got %s" (utils/type-of schema))
   (with-meta (Record. klass schema) {:konstructor map-constructor}))
 

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -199,7 +199,8 @@
       #?@(:clj [java.util.regex.Pattern 'Regex])
       #?(:clj java.util.Date :cljs js/Date) 'Inst
       #?(:clj java.util.UUID :cljs cljs.core/UUID) 'Uuid
-      #?(:clj (or #?(:bb (when (symbol? this) this))
+      #?(:clj (or #?(:bb (when (instance? sci.lang.Type this)
+                           (symbol (str this))))
                   (symbol (.getName ^Class this)))
          :cljs this))))
 
@@ -208,7 +209,7 @@
      :cljs function)
   (spec [this] (-class-spec this))
   (explain [this] (-class-explain this))
-  #?@(:bb [clojure.lang.Symbol
+  #?@(:bb [sci.lang.Type
            (spec [this] (-class-spec this))
            (explain [this] (-class-explain this))]))
 
@@ -1034,13 +1035,14 @@
      (map-elements schema)
      (map-error)))
   (explain [this]
-    (list 'record #?(:clj (or #?(:bb (when (symbol? klass) klass))
+           (list 'record #?(:clj (or #?(:bb (when (instance? sci.lang.Type klass)
+                                              (symbol (str klass))))
                               (symbol (.getName ^Class klass)))
                      :cljs (symbol (pr-str klass)))
           (explain schema))))
 
 (clojure.core/defn record* [klass schema map-constructor]
-  #?(:bb (macros/assert! (or (class? klass) (symbol? klass)) "Expected record class or symbol, got %s" (utils/type-of klass))
+  #?(:bb (macros/assert! (or (class? klass) (instance? sci.lang.Type klass)) "Expected record class or symbol, got %s" (utils/type-of klass))
      :clj (macros/assert! (class? klass) "Expected record class, got %s" (utils/type-of klass)))
   (macros/assert! (map? schema) "Expected map, got %s" (utils/type-of schema))
   (with-meta (Record. klass schema) {:konstructor map-constructor}))

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -172,7 +172,7 @@
 
 ;; On the JVM, a Class itself is a schema. In JS, we treat functions as prototypes so any
 ;; function prototype checks objects for compatibility. In BB, defrecord classes can also be
-;; symbols.
+;; instances of sci.lang.Type, and the interpreter extends `instance?` to support it as first arg.
 
 (clojure.core/defn instance-precondition [s klass]
   (spec/precondition

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1042,7 +1042,7 @@
           (explain schema))))
 
 (clojure.core/defn record* [klass schema map-constructor]
-  (macros/assert! (or (class? klass) #?(:bb (instance? sci.lang.Type klass))) "Expected record class, got %s" (utils/type-of klass))
+  #?(:clj (macros/assert! (or (class? klass) #?(:bb (instance? sci.lang.Type klass))) "Expected record class, got %s" (utils/type-of klass)))
   (macros/assert! (map? schema) "Expected map, got %s" (utils/type-of schema))
   (with-meta (Record. klass schema) {:konstructor map-constructor}))
 

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -193,10 +193,10 @@
   (if-let [more-schema (utils/class-schema this)]
     (explain more-schema)
     (condp = this
-      #?(:clj java.lang.String :cljs nil) 'Str
+      #?@(:clj [java.lang.String 'Str])
       #?(:clj java.lang.Boolean :cljs js/Boolean) 'Bool
       #?(:clj java.lang.Number :cljs js/Number) 'Num
-      #?(:clj java.util.regex.Pattern :cljs nil) 'Regex
+      #?@(:clj [java.util.regex.Pattern 'Regex])
       #?(:clj java.util.Date :cljs js/Date) 'Inst
       #?(:clj java.util.UUID :cljs cljs.core/UUID) 'Uuid
       #?(:clj (or #?(:bb (when (symbol? this) this))

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1035,8 +1035,8 @@
      (map-elements schema)
      (map-error)))
   (explain [this]
-           (list 'record #?(:clj (or #?(:bb (when (instance? sci.lang.Type klass)
-                                              (symbol (str klass))))
+    (list 'record #?(:clj (or #?(:bb (when (instance? sci.lang.Type klass)
+                                       (symbol (str klass))))
                               (symbol (.getName ^Class klass)))
                      :cljs (symbol (pr-str klass)))
           (explain schema))))

--- a/src/cljc/schema/utils.cljc
+++ b/src/cljc/schema/utils.cljc
@@ -30,7 +30,8 @@
   "What class can we associate the fn schema with? In Clojure use the class of the fn; in
    cljs just use the fn itself."
   [f]
-  #?(:clj (class f)
+  #?(:bb f
+     :clj (class f)
      :cljs f))
 
 (defn format* [fmt & args]
@@ -150,8 +151,9 @@
    schema only applies to instances of the concrete type passed, i.e.,
    (= (class x) klass), not (instance? klass x)."
     [klass schema]
-    (assert (class? klass)
-            (format* "Cannot declare class schema for non-class %s" (class klass)))
+    #?(:bb nil ;; fn identity is used as klass in bb
+       :default (assert (class? klass)
+                        (format* "Cannot declare class schema for non-class %s" (pr-str (class klass)))))
     (.put +class-schemata+ klass schema))
 
   (defn class-schema
@@ -176,5 +178,6 @@
    s/compile-fn-validation was true -- has no effect for functions compiled
    when it is false."
   ;; specialize in Clojure for performance
-  #?(:clj (java.util.concurrent.atomic.AtomicReference. false)
+  #?(:bb (atom false)
+     :clj (java.util.concurrent.atomic.AtomicReference. false)
      :cljs (atom false)))

--- a/test/bb/schema/bb_test_runner.clj
+++ b/test/bb/schema/bb_test_runner.clj
@@ -1,0 +1,23 @@
+(ns schema.bb-test-runner
+  (:require [clojure.test :as t]
+            [babashka.classpath :as cp]))
+
+(def test-nsyms [;'schema.experimental.complete-test ;;deprecated
+                 ;'schema.experimental.generators-test ;; deprecated
+                 'schema.core-test
+                 'schema.macros-test
+                 'schema.coerce-test
+                 'schema.experimental.abstract-map-test
+                 'schema.test-test
+                 'schema.utils-test])
+
+(apply require test-nsyms)
+
+(def test-results
+  (apply t/run-tests test-nsyms))
+
+(def failures-and-errors
+  (let [{:keys [:fail :error]} test-results]
+    (+ fail error)))
+
+(System/exit failures-and-errors)

--- a/test/cljc/schema/core_test.cljc
+++ b/test/cljc/schema/core_test.cljc
@@ -14,7 +14,8 @@
   #?(:cljs (:require-macros [schema.macros :as macros]))
   (:require
    [clojure.string :as str]
-   #?(:clj [clojure.pprint :as pprint])
+   [#?(:clj clojure.pprint
+       :cljs cljs.pprint) :as pprint]
    clojure.data
    [schema.utils :as utils]
    [schema.core :as s]
@@ -48,9 +49,11 @@
 
 (deftest fn-name-test
   (is (= "odd?" (utils/fn-name odd?)))
-  (is (= #?(:clj "schema.core-test/foo-bar" :cljs "foo-bar")
-         (utils/fn-name foo-bar)))
-  #?(:clj (is (= "schema.core-test$fn" (subs (utils/fn-name (fn foo [x] (+ x x))) 0 19))))
+  #?(:bb nil
+     :default (is (= #?(:clj "schema.core-test/foo-bar" :cljs "foo-bar")
+                     (utils/fn-name foo-bar))))
+  #?(:bb nil
+     :clj (is (= "schema.core-test$fn" (subs (utils/fn-name (fn foo [x] (+ x x))) 0 19))))
   #?(:cljs (is (= "foo" (utils/fn-name (fn foo [x] (+ x x))))))
   #?(:cljs (is (= "function" (utils/fn-name (fn [x] (+ x x)))))))
 
@@ -82,7 +85,7 @@
 
   (deftest array-test
     (valid! (Class/forName"[Ljava.lang.String;") (into-array String ["a"]))
-    (invalid! (Class/forName "[Ljava.lang.Long;") (into-array String ["a"]))
+    (invalid! (Class/forName #?(:bb "[Ljava.lang.Double;" :default "[Ljava.lang.Long;")) (into-array String ["a"]))
     (valid! (Class/forName "[Ljava.lang.Double;") (into-array Double [1.0]))
     (valid! (Class/forName "[D") (double-array [1.0]))
     (invalid! (Class/forName "[D") (into-array Double [1.0]))
@@ -138,27 +141,51 @@
     (is (= '(pred odd?) (s/explain schema)))
     (invalid! (s/pred odd?) 2 "(not (odd? 2))")))
 
-(defprotocol ATestProtocol)
+(defprotocol ATestMarkerProtocol)
 
-(s/defn ^:always-validate a-test-protocol-fn
+(s/defn ^:always-validate a-test-marker-protocol-fn
+  "Compile the schema before extending, make sure it works as expected"
+  [x :- (s/protocol ATestMarkerProtocol)]
+  x)
+
+(defrecord DirectTestMarkerProtocolSatisfier [] ATestMarkerProtocol)
+(defrecord IndirectTestMarkerProtocolSatisfier []) (extend-type IndirectTestMarkerProtocolSatisfier ATestMarkerProtocol)
+(defrecord NonTestMarkerProtocolSatisfier [])
+
+(deftest marker-protocol-test
+ (let [schema (s/protocol ATestMarkerProtocol)]
+   (valid! schema (DirectTestMarkerProtocolSatisfier.))
+   (valid! schema (IndirectTestMarkerProtocolSatisfier.))
+   (invalid! schema (NonTestMarkerProtocolSatisfier.))
+   (invalid! schema nil)
+   (invalid! schema 117 "(not (satisfies? ATestMarkerProtocol 117))")
+   (is (a-test-marker-protocol-fn (DirectTestMarkerProtocolSatisfier.)))
+   (is (a-test-marker-protocol-fn (IndirectTestMarkerProtocolSatisfier.)))
+   (invalid-call! a-test-marker-protocol-fn (NonTestMarkerProtocolSatisfier.))
+   (is (= '(protocol ATestMarkerProtocol) (s/explain schema)))))
+
+(defprotocol ATestProtocol
+  (not-marker-protocol [this]))
+
+(s/defn ^:always-validate a-test-non-marker-protocol-fn
   "Compile the schema before extending, make sure it works as expected"
   [x :- (s/protocol ATestProtocol)]
   x)
 
-(defrecord DirectTestProtocolSatisfier [] ATestProtocol)
-(defrecord IndirectTestProtocolSatisfier []) (extend-type IndirectTestProtocolSatisfier ATestProtocol)
+(defrecord DirectTestProtocolSatisfier [] ATestProtocol (not-marker-protocol [this]))
+(defrecord IndirectTestProtocolSatisfier []) (extend-type IndirectTestProtocolSatisfier ATestProtocol (not-marker-protocol [this]))
 (defrecord NonTestProtocolSatisfier [])
 
-(deftest protocol-test
+(deftest non-marker-protocol-test
   (let [schema (s/protocol ATestProtocol)]
     (valid! schema (DirectTestProtocolSatisfier.))
     (valid! schema (IndirectTestProtocolSatisfier.))
     (invalid! schema (NonTestProtocolSatisfier.))
     (invalid! schema nil)
     (invalid! schema 117 "(not (satisfies? ATestProtocol 117))")
-    (is (a-test-protocol-fn (DirectTestProtocolSatisfier.)))
-    (is (a-test-protocol-fn (IndirectTestProtocolSatisfier.)))
-    (invalid-call! a-test-protocol-fn (NonTestProtocolSatisfier.))
+    (is (a-test-non-marker-protocol-fn (DirectTestProtocolSatisfier.)))
+    (is (a-test-non-marker-protocol-fn (IndirectTestProtocolSatisfier.)))
+    (invalid-call! a-test-non-marker-protocol-fn (NonTestProtocolSatisfier.))
     (is (= '(protocol ATestProtocol) (s/explain schema)))))
 
 (deftest regex-test
@@ -476,7 +503,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Handle Struct
 
-#?(:clj
+#?(:bb nil
+:clj
 (do (defstruct ts1 :num :str :map :vec)
     (defstruct ts2 :num :str)
 
@@ -619,8 +647,8 @@
   (let [schema [s/Str]]
     (valid! schema (java.util.ArrayList. ^java.util.Collection (identity ["hi" "bye"])))
     (invalid! schema (java.util.ArrayList. ^java.util.Collection (identity [1 2])))
-    (valid! schema (java.util.LinkedList. ^java.util.Collection (identity ["hi" "bye"])))
-    (invalid! schema (java.util.LinkedList. ^java.util.Collection (identity [1 2])))
+    #?(:bb nil :default (valid! schema (java.util.LinkedList. ^java.util.Collection (identity ["hi" "bye"]))))
+    #?(:bb nil :default (invalid! schema (java.util.LinkedList. ^java.util.Collection (identity [1 2]))))
     (valid! schema java.util.Collections/EMPTY_LIST)
     (invalid! schema java.util.Collections/EMPTY_MAP)
     (invalid! schema #{"hi" "bye"}))))
@@ -635,7 +663,7 @@
     (valid! schema (Foo. :foo 1))
     (invalid! schema {:x :foo :y 1})
     (invalid! schema (assoc (Foo. :foo 1) :bar 2))
-    #?(:clj (is (= '(record schema.core_test.Foo {:x Any,  (optional-key :y) Int})
+    #?(:clj (is (= '(record schema.core_test.Foo {:x Any, (optional-key :y) Int})
                    (s/explain schema))))))
 
 (deftest record-with-extra-keys-test
@@ -645,7 +673,6 @@
     (valid! schema (Foo. :foo 1))
     (valid! schema (assoc (Foo. :foo 1) :bar 2))
     (invalid! schema {:x :foo :y 1})))
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Function Schemas
@@ -821,8 +848,10 @@
 (do (s/defrecord RecordWithPrimitive [x :- long])
     (deftest record-with-primitive-test
       (valid! RecordWithPrimitive (RecordWithPrimitive. 1))
-      (is (thrown? Exception (RecordWithPrimitive. "a")))
-      (is (thrown? Exception (RecordWithPrimitive. nil))))))
+      #?(:bb (do (is (invalid! RecordWithPrimitive (RecordWithPrimitive. "a")))
+                 (is (invalid! RecordWithPrimitive (RecordWithPrimitive. nil))))
+         :default (do (is (thrown? Exception (RecordWithPrimitive. "a")))
+                      (is (thrown? Exception (RecordWithPrimitive. nil))))))))
 
 (deftest map->record-test
   (let [subset {:foo 1 :bar "a"}
@@ -866,7 +895,7 @@
   (let [f (s/fn ^s/Str foo [^OddLong arg0 arg1])]
     (is (= +test-fn-schema+ (s/fn-schema f)))))
 
-#?(:clj
+#?(:bb nil :clj
 (deftest no-wrapper-fn-test
   (let [f (s/fn this [] this)]
     (is (identical? f (f))))))
@@ -887,7 +916,8 @@
     (s/with-fn-validation
       (is (= 4 (f 1 {:foo 3})))
       ;; Primitive Interface Test
-      #?(:clj (is (thrown? Exception (.invokePrim ^clojure.lang.IFn$LOL f 1 {:foo 3})))) ;; primitive type hints don't work on fns
+      #?(:bb nil
+         :clj (is (thrown? Exception (.invokePrim ^clojure.lang.IFn$LOL f 1 {:foo 3})))) ;; primitive type hints don't work on fns
       (invalid-call! f 1 {:foo 4})  ;; foo not odd?
       (invalid-call! f 2 {:foo 3})) ;; return not even?
 
@@ -896,7 +926,8 @@
     (is (= 5 (f 2 {:foo 3})))     ;; return not even?
     (let [fthiss @fthiss]
       (is (seq fthiss))
-      #?(:clj (is (every? #(identical? % f) fthiss)))))
+      #?(:bb nil
+         :clj (is (every? #(identical? % f) fthiss)))))
   (testing
     "Tests that the anonymous function schema macro can handle a
     name, a schema without a name and no return schema."
@@ -996,7 +1027,7 @@
 (deftest infinite-arity-fn-test
   (let [f (s/fn foo :- s/Int
             ([^s/Int arg0] (inc arg0))
-            ([^s/Int arg0  & strs :- [s/Str]]
+            ([^s/Int arg0 & strs :- [s/Str]]
                (reduce + (foo arg0) (map count strs))))]
     (is (= (s/=>* s/Int [s/Int] [s/Int & [s/Str]])
            (s/fn-schema f)))
@@ -1020,7 +1051,8 @@
         (invalid-call! f 4 9 2))
       (let [fthiss @fthiss]
         (is (seq fthiss))
-        #?(:clj (is (every? #(identical? % f) fthiss))))))
+        #?(:bb nil
+           :clj (is (every? #(identical? % f) fthiss))))))
   (testing "arg schema"
     (let [f (s/fn foo :- s/Int
               [^s/Int arg0 & [rest0 :- s/Int]] (+ arg0 (or rest0 2)))]
@@ -1103,11 +1135,10 @@
     (invalid-call! validated-pre-post-defn 11)
     (invalid-call! validated-pre-post-defn 1)
     (invalid-call! validated-pre-post-defn "a"))
-  (comment ;; Triggers what seems to be a bug in cljs, fixed in latest version.
-    (let [e (try (s/with-fn-validation (simple-validated-defn 2)) nil
-                 (catch js/Error e e))]
-      (when e ;; validation can be disabled at compile time, and exception not thrown
-        (is (>= (.indexOf (str e) +bad-input-str+) 0)))))
+  (let [e (try (s/with-fn-validation (simple-validated-defn 2)) nil
+               (catch js/Error e e))]
+    (when e ;; validation can be disabled at compile time, and exception not thrown
+      (is (>= (.indexOf (str e) +bad-input-str+) 0))))
   (is (= +simple-validated-defn-schema+ (s/fn-schema simple-validated-defn)))))
 
 #?(:clj
@@ -1123,10 +1154,12 @@
 (deftest simple-validated-defn-test
   (is (= "Inputs: [arg0 :- OddLong]\n  Returns: OddLongString\n\n  I am a simple schema fn"
          (:doc (meta #'simple-validated-defn))))
-  (is (= '([arg0]) (:arglists (meta #'simple-validated-defn))))
+  #?(:bb nil
+     :default (is (= '([arg0]) (:arglists (meta #'simple-validated-defn)))))
   (is (= "Inputs: ([arg0 :- OddLong] [arg0 :- OddLong arg1 :- Long])\n  Returns: OddLongString\n\n  I am a multi-arglist schema fn"
          (:doc (meta #'multi-arglist-validated-defn))))
-  (is (= '([arg0] [arg0 arg1]) (:arglists (meta #'multi-arglist-validated-defn))))
+  #?(:bb nil
+     :default (is (= '([arg0] [arg0 arg1]) (:arglists (meta #'multi-arglist-validated-defn)))))
   (s/with-fn-validation
     (testing "pre/post"
       (is (= 7 (validated-pre-post-defn 7)))
@@ -1151,8 +1184,9 @@
   (is (= "4" (simple-validated-defn 4)))
   (let [^Exception e (try (s/with-fn-validation (simple-validated-defn 2)) nil (catch Exception e e))]
     (is (.contains (.getMessage e) +bad-input-str+))
-    (is (.contains (.getClassName ^StackTraceElement (first (.getStackTrace e))) "simple_validated_defn"))
-    (is (.startsWith (.getFileName ^StackTraceElement (first (.getStackTrace e))) "core_test.clj")))))
+    #?(:bb nil
+       :default (do (is (.contains (.getClassName ^StackTraceElement (first (.getStackTrace e))) "simple_validated_defn"))
+                    (is (.startsWith (.getFileName ^StackTraceElement (first (.getStackTrace e))) "core_test.clj")))))))
 
 (s/defn ^:always-validate always-validated-defn :- (s/pred even?)
   [x :- (s/pred pos?)]
@@ -1294,10 +1328,12 @@
   (deftest simple-primitive-validated-defn-test
     (is (= +primitive-validated-defn-schema+ (s/fn-schema primitive-validated-defn)))
 
-    (is ((ancestors (class primitive-validated-defn)) clojure.lang.IFn$LL))
+    #?(:bb nil
+       :default (is ((ancestors (class primitive-validated-defn)) clojure.lang.IFn$LL)))
     (s/with-fn-validation
       (is (= 4 (primitive-validated-defn 3)))
-      (is (= 4 (.invokePrim ^clojure.lang.IFn$LL primitive-validated-defn 3)))
+       #?(:bb nil
+          :default (is (= 4 (.invokePrim ^clojure.lang.IFn$LL primitive-validated-defn 3))))
       (is (thrown? Exception (primitive-validated-defn 4))))
 
     (is (= 5 (primitive-validated-defn 4))))
@@ -1307,7 +1343,8 @@
     1.0)
 
   (deftest another-primitive-fn-test
-    (is ((ancestors (class another-primitive-fn)) clojure.lang.IFn$LD))
+    #?(:bb nil
+       :default (is ((ancestors (class another-primitive-fn)) clojure.lang.IFn$LD)))
     (is (= 1.0 (another-primitive-fn 10))))))
 
 
@@ -1416,13 +1453,17 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;  Regression tests
 
+;; map implementation takes precedence in cljs
 #?(:clj
-(deftest pprint-test
-  (is (= "(maybe Int)" (str/trim (with-out-str (pprint/pprint (s/maybe s/Int))))))))
+   (deftest pprint-test
+     (is (= "(maybe Int)" (str/trim (with-out-str (pprint/pprint (s/maybe s/Int))))))))
+
+(deftest print-test
+  (is (= "(maybe Int)" (pr-str (s/maybe s/Int)))))
 
 (defrecord ItemTest [first second])
 
-(defrecord CacheTest [schema]
+(macros/defrecord-schema CacheTest [schema]
   s/Schema
   (spec [this]
     (collection/collection-spec

--- a/test/cljc/schema/utils_test.cljc
+++ b/test/cljc/schema/utils_test.cljc
@@ -7,6 +7,7 @@
 
 (defn ^:private a-defn-function-with-a-normal-name [a b c d])
 
+#?(:bb nil :default
 (deftest fn-name-test
   (are [in pattern] (re-matches pattern (utils/fn-name in))
 
@@ -26,4 +27,4 @@
 
     #(+ 1 2)
     #?(:clj #"schema\.utils-test.*"
-       :cljs #"function")))
+       :cljs #"function"))))


### PR DESCRIPTION
The next version of [babashka](https://github.com/babashka/babashka) will be able to support schema with these changes.

The main thing to note here is that babashka cannot dynamically create classes (since it runs on graalvm), so `cc/fn`, `cc/defrecord`, `cc/defprotocol` have very different implementations than JVM Clojure.

Here, it mostly amounts to broadening `class?` checks to also account for `sci.lang.Type`, which is babashka's representation of dynamically generated classes.

We also use fn identity for `s/fn-schema` since bb keeps a pool of its own `fn` classes for each arity, and revert to less optimized CLJS approach in some other places.

Note: in bb, both `:clj` and `:bb` reader conditionals are active.

Note: in `schema.macros`, we can't use reader conditionals (`.clj`) so `if-bb` uses system props to determine platform.

Note: bb doesn't support extending `print-method` via a protocol, so `macros/defrecord-schema` is used to extend it for each schema primitive.

Bonus: adds pretty `pr-str` printing in CLJS.

The entire test suite remarkably runs in 0.5 seconds:

```
$ bash <(curl https://raw.githubusercontent.com/babashka/babashka/master/install) --version 0.8.3-SNAPSHOT --dir .
$ time ./bb test

Testing schema.core-test

Testing schema.macros-test

Testing schema.coerce-test

Testing schema.experimental.abstract-map-test

Testing schema.test-test

Testing schema.utils-test

Ran 121 tests containing 660 assertions.
0 failures, 0 errors.
./bb test  0.46s user 0.05s system 98% cpu 0.517 total
```