### PR TITLE
Add clj-kondo exports

### DIFF
--- a/resources/clj-kondo.exports/prismatic/schema/config.edn
+++ b/resources/clj-kondo.exports/prismatic/schema/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {schema.test/deftest clojure.test/deftest}}


### PR DESCRIPTION
Hey folks!

Recently I discovered that every time I want to check my projects (that use this library) with schema/deftest, Clojure-lsp (and for instance clj-kondo?) is unable to lint in the right way, so I think the best approach should be having those exports directly in the library following [this guide](https://github.com/clj-kondo/clj-kondo/blob/master/doc/config.md#exporting), please if this doesn't make sense at all for you, let me know and maybe we cand o a quick sync.