### PR TITLE
Introduce polymorphic schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,41 @@ You can also write sequence schemas that expect particular values in specific po
 ;;   (not (instance? java.lang.Number "4"))]
 ```
 
+### Polymorphic schemas
+
+Macros such as `s/defn` can define functions with polymorphic schemas. At runtime, they will be checked
+by expanding polymorphic variables to their most general values. For example, at runtime `identity-mono`
+and `identity-poly` are instrumented in the same way:
+
+```clojure
+(s/defn identity-mono :- s/Any
+  [x :- s/Any]
+  x)
+
+(s/defn :all [T]
+  identity-poly :- T
+  [x :- T]
+  x)
+```
+
+The actual value chosen as the "most general" depends on the schema variables kind and should not be
+relied on. In the future, schema variables may be instantiated with other values.
+
+Dotted variables have an internal "most general" value which represents a homogeneous sequence of
+generalized templates (ie., generalizing variables to the left of the `:..`).
+The following two functions are instrumented in the same way.
+
+```clojure
+(s/defn :all [T :..]
+  rest-args-poly :- T
+  [& xs :- {:a T} :.. T]
+  x)
+
+(s/defn rest-args-mono :- s/Any
+  [& xs :- [{:a s/Any}]]
+  x)
+```
+
 ### Other schema types
 
 [`schema.core`](https://github.com/plumatic/schema/blob/master/src/cljc/schema/core.cljc) provides many more utilities for building schemas, including `maybe`, `eq`, `enum`, `pred`, `conditional`, `cond-pre`, `constrained`, and more.  Here are a few of our favorites:

--- a/README.md
+++ b/README.md
@@ -315,13 +315,13 @@ generalized templates (ie., generalizing variables to the left of the `:..`).
 The following two functions are instrumented in the same way.
 
 ```clojure
-(s/defn :all [T :..]
-  rest-args-poly :- T
-  [& xs :- {:a T} :.. T]
+(s/defn :all [S T :..]
+  rest-args-poly :- S
+  [& xs :- {:a S :b T} :.. T]
   x)
 
 (s/defn rest-args-mono :- s/Any
-  [& xs :- [{:a s/Any}]]
+  [& xs :- [{:a s/Any :b s/Any}]]
   x)
 ```
 

--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ and `identity-poly` are instrumented in the same way:
   x)
 ```
 
-The actual value chosen as the "most general" depends on the schema variables kind and should not be
-relied on. In the future, schema variables may be instantiated with other values.
+The actual value chosen as the "most general" depends on the polymorphic variables kind and should not be
+relied on. In the future, polymorphic variables may be instantiated with other values.
 
 Dotted variables have an internal "most general" value which represents a homogeneous sequence of
 generalized templates (ie., generalizing variables to the left of the `:..`).

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -164,7 +164,7 @@
                                                            `(let [template# (fn [~dvar] ~template)]
                                                               (cond
                                                                 (instance? schema.core.AnyDotted ~dvar)
-                                                                (template# (:schema ~dvar))
+                                                                [(template# (:schema ~dvar))]
 
                                                                 (vector? ~dvar)
                                                                 [(apply s/cond-pre ~dvar)]

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -376,7 +376,7 @@
   (let [compile-validation (compile-fn-validation? env name)
         output-schema (extract-schema-form name)
         output-schema-sym (gensym "output-schema")
-        poly-binder (-> name meta ::binder)
+        poly-binder (-> name meta ::poly-binder)
         bind-meta (or (when-let [t (:tag (meta name))]
                         (when (primitive-sym? t)
                           {:tag t}))
@@ -514,7 +514,7 @@
          leading-opts {}]
     (if (= :all k)
       (do (assert! v-provided (str "Missing value for key " k))
-          (recur next-macro-args (assoc leading-opts k v)))
+          (recur next-macro-args (assoc leading-opts ::poly-binder v)))
       [leading-opts macro-args])))
 
 (defn normalized-defn-args
@@ -530,7 +530,7 @@
         [maybe-attr-map macro-args] (maybe-split-first map? macro-args)]
     (cons (vary-meta name merge
                      (or maybe-attr-map {})
-                     (when (:all leading-opts) {::binder (:all leading-opts)})
+                     leading-opts
                      (when maybe-docstring {:doc maybe-docstring}))
           macro-args)))
 

--- a/src/clj/schema/macros.clj
+++ b/src/clj/schema/macros.clj
@@ -399,7 +399,7 @@
      :arglists (map :arglist processed-arities)
      :raw-arglists (map :raw-arglist processed-arities)
      :schema-form (if poly-binder
-                    ;; can't reuse output-schema-sym or schema-bindings as type variables are instantiated via poly-binder-outer-bindings
+                    ;; can't reuse output-schema-sym or schema-bindings since its type variables are instantiated via poly-binder-outer-bindings
                     `(schema.core/all ~poly-binder
                                       ~(if (= 1 (count processed-arities))
                                          `(schema.core/->FnSchema ~output-schema ~[(-> schema-bindings first second)])

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1116,7 +1116,8 @@
    :- assigns a kind to a polymorphic variable. By default, polymorphic variables are kind :schema.
 
    1. [T :- :schema]   represents a Schema, eg., s/Any, s/Int, (s/=> s/Int s/Bool)
-   2. [T :- :..]       represents a vector of schemas of kind KIND.
+   2. [T :- :..]       represents a vector of schemas, often to represent heterogenous rest arguments
+                       eg., [s/Int s/Bool]
 
    [T :..] is sugar for [T :- :..]"
   [decl schema]
@@ -1179,12 +1180,16 @@
 
    Dotted schemas may be used as rest schemas, and will be immediately expanded.
 
-   For example, if `Y :..` is in scope then (s/=> Z X [Y] :.. Y) represents the following functions:
-    (s/=> Z X)
-    (s/=> Z X [Y0])
-    (s/=> Z X [Y0] [Y1])
-    (s/=> Z X [Y0] [Y1] [Y1])
+   For example, if `Y :..` is in scope then (=> Z X [Y] :.. Y) represents the following functions:
+    (=> Z X)
+    (=> Z X [Y0])
+    (=> Z X [Y0] [Y1])
+    (=> Z X [Y0] [Y1] [Y1])
     ...etc
+
+   Depending on the instantiation of Y, the schema at runtime will be one of the above or
+   the following schema that encapsulates them all:
+    (=> Z X & [s/Any])
 
    Currently function schemas are purely descriptive; there is no validation except for
    functions defined directly by s/fn or s/defn"

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1187,9 +1187,9 @@
     (=> Z X [Y0] [Y1] [Y1])
     ...etc
 
-   Depending on the instantiation of Y, the schema at runtime will be one of the above or
-   the following schema that encapsulates them all:
-    (=> Z X & [s/Any])
+   Depending on the instantiation of Y, the schema at runtime will be one of the above with
+   concretized Y's or the following schema that encapsulates them all:
+    (=> Z X & [[s/Any]])
 
    Currently function schemas are purely descriptive; there is no validation except for
    functions defined directly by s/fn or s/defn"

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1178,7 +1178,8 @@
    each of which is a vector of argument schemas, ending with an optional '& more-schema'
    specification where more-schema must be a sequence schema.
 
-   Dotted schemas may be used as rest schemas, and will be immediately expanded.
+   Dotted schemas are allowed as the final arguments, and will be expanded into either fixed
+   or rest arguments upon evaluation.
 
    For example, if `Y :..` is in scope then (=> Z X [Y] :.. Y) represents the following functions:
     (=> Z X)

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1179,7 +1179,7 @@
 
    Dotted schemas may be used as rest schemas, and will be immediately expanded.
 
-   For example, if `Y :..` is in scope then (s/=> Z X & [Y] :.. Y) represents the following functions:
+   For example, if `Y :..` is in scope then (s/=> Z X [Y] :.. Y) represents the following functions:
     (s/=> Z X)
     (s/=> Z X [Y0])
     (s/=> Z X [Y0] [Y1])
@@ -1452,7 +1452,7 @@
 
    (s/defn :all [X Y :.. Z]
      map :- [Z]
-     [f :- (=> Z X & Y :.. Y)
+     [f :- (=> Z X Y :.. Y)
       xs :- [X]
       & xss :- [Y] :.. Y]
      (apply map f xs xss))

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1110,10 +1110,10 @@
 (defmacro all
   "Create a polymorphic function schema.
   
-   Binder declaration is a vector of schema variables and its kinds.
+   Binder declaration is a vector of polymorphic variables and its kinds.
 
    Schema variables have a 'kind' that classify what it represents.
-   :- assigns a kind to a schema variable. By default, schema variables are kind :schema.
+   :- assigns a kind to a polymorphic variable. By default, polymorphic variables are kind :schema.
 
    1. [T :- :schema]   represents a Schema, eg., s/Any, s/Int, (s/=> s/Int s/Bool)
    2. [T :- :..]       represents a vector of schemas of kind KIND.
@@ -1424,20 +1424,20 @@
    See (doc schema.core) for details of the :- syntax for arguments and return
    schemas.
 
-   You can use :all to make a polymorphic schema by binding schema variables.
-   See `s/all` for more about schema variables.
+   You can use :all to make a polymorphic schema by binding polymorphic variables.
+   See `s/all` for more about polymorphic variables.
  
-   The schema variables are scoped inside the function body. Note, they will usually be bound
+   The polymorphic variables are scoped inside the function body. Note, they will usually be bound
    to their most general values (eg., s/Any) at runtime. This strategy also informs how
-   `s/with-fn-validation` treats schema variables. However, the values of schema
+   `s/with-fn-validation` treats polymorphic variables. However, the values of schema
    variables should always be treated as opaque.
 
-   In the body of the function, names provided by argument vectors may shadow schema variables.
+   In the body of the function, names provided by argument vectors may shadow polymorphic variables.
 
    (s/defn :all [T]
     my-identity :- T
     [x :- T]
-    ;; from here, (destructured) arguments shadow schema variables
+    ;; from here, (destructured) arguments shadow polymorphic variables
     ...
     ;; usually equivalent to (s/validate s/Any x)
     (s/validate T x))

--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -1507,7 +1507,7 @@
         {:keys [outer-bindings schema-form fn-body arglists raw-arglists]} (macros/process-fn- &env name more-defn-args)]
     `(let ~outer-bindings
        (let [ret# (clojure.core/defn ~(with-meta name {})
-                    ~(assoc (apply dissoc standard-meta ::macros/binder (when (macros/primitive-sym? tag) [:tag]))
+                    ~(assoc (apply dissoc standard-meta ::macros/poly-binder (when (macros/primitive-sym? tag) [:tag]))
                        :doc (str
                              (str "Inputs: " (if (= 1 (count raw-arglists))
                                                (first raw-arglists)

--- a/src/cljc/schema/spec/core.cljc
+++ b/src/cljc/schema/spec/core.cljc
@@ -11,7 +11,7 @@
 
 (defprotocol CoreSpec
   "Specs are a common language for Schemas to express their structure.
-   These two use-cases aren't priveledged, just the two that are considered core
+   These two use-cases aren't privileged, just the two that are considered core
    to being a Spec."
   (subschemas [this]
     "List all subschemas")

--- a/test/clj/schema/macros_test.clj
+++ b/test/clj/schema/macros_test.clj
@@ -4,8 +4,22 @@
    [schema.core :as s]
    [schema.macros :as macros]))
 
+(deftest extract-leading-fn-kv-pairs-test
+  (is (= (macros/extract-leading-fn-kv-pairs [])
+         [{} []]))
+  (is (= (macros/extract-leading-fn-kv-pairs ['name :- 'schema])
+         [{} ['name :- 'schema]]))
+  (is (= (macros/extract-leading-fn-kv-pairs [:all '[x] 'name :- 'schema])
+         [{:all '[x]} ['name :- 'schema]]))
+  (is (= (macros/extract-leading-fn-kv-pairs [:- '[s/Any] :- 'schema])
+         [{} [:- '[s/Any] :- 'schema]]))
+  (is (= (macros/extract-leading-fn-kv-pairs [:all '[x] :- '[s/Any] :- 'schema])
+         [{:all '[x]} [:- '[s/Any] :- 'schema]])))
+
 (deftest normalized-defn-args-test
   (doseq [explicit-meta [{} {:a -1 :c 3}]
+          [leading-map leading-forms] {{} []
+                                       '{::macros/binder [x]} '[:all [x]]}
           [schema-attrs schema-forms] {{:schema `s/Any} []
                                        {:schema 'Long :tag 'Long} [:- 'Long]}
           [doc-attrs doc-forms] {{} []
@@ -13,10 +27,10 @@
           [attr-map attr-forms] {{} {}
                                  {:a 1 :b 2} [{:a 1 :b 2}]}]
     (let [simple-body ['[x] `(+ 1 1)]
-          full-args (concat [(with-meta 'abc explicit-meta)] schema-forms doc-forms attr-forms simple-body)
+          full-args (concat leading-forms [(with-meta 'abc explicit-meta)] schema-forms doc-forms attr-forms simple-body)
           [name & more] (macros/normalized-defn-args {} full-args)]
       (testing (vec full-args)
-        (is (= (concat ['abc (merge explicit-meta schema-attrs doc-attrs attr-map) simple-body])
+        (is (= (concat ['abc (merge explicit-meta schema-attrs doc-attrs attr-map leading-map) simple-body])
                (concat [name (meta name) more])))))))
 
 (deftest compile-fn-validation?-test

--- a/test/clj/schema/macros_test.clj
+++ b/test/clj/schema/macros_test.clj
@@ -10,16 +10,16 @@
   (is (= (macros/extract-leading-fn-kv-pairs ['name :- 'schema])
          [{} ['name :- 'schema]]))
   (is (= (macros/extract-leading-fn-kv-pairs [:all '[x] 'name :- 'schema])
-         [{:all '[x]} ['name :- 'schema]]))
+         [{::macros/poly-binder '[x]} ['name :- 'schema]]))
   (is (= (macros/extract-leading-fn-kv-pairs [:- '[s/Any] :- 'schema])
          [{} [:- '[s/Any] :- 'schema]]))
   (is (= (macros/extract-leading-fn-kv-pairs [:all '[x] :- '[s/Any] :- 'schema])
-         [{:all '[x]} [:- '[s/Any] :- 'schema]])))
+         [{::macros/poly-binder '[x]} [:- '[s/Any] :- 'schema]])))
 
 (deftest normalized-defn-args-test
   (doseq [explicit-meta [{} {:a -1 :c 3}]
           [leading-map leading-forms] {{} []
-                                       '{::macros/binder [x]} '[:all [x]]}
+                                       '{::macros/poly-binder [x]} '[:all [x]]}
           [schema-attrs schema-forms] {{:schema `s/Any} []
                                        {:schema 'Long :tag 'Long} [:- 'Long]}
           [doc-attrs doc-forms] {{} []

--- a/test/cljc/schema/core_test.cljc
+++ b/test/cljc/schema/core_test.cljc
@@ -1610,7 +1610,8 @@
            poly-identity
            poly-first
            poly-map-nodot
-           poly-map-dot]} :- PolySemanticsTestSuite]
+           poly-map-dot
+           poly-map-dot-arities]} :- PolySemanticsTestSuite]
   (is (= 1 (s/with-fn-validation (args-shadow-schema-variables 1))))
   (is (= 1 (s/with-fn-validation (poly-identity 1))))
   (is (= :a (s/with-fn-validation (poly-identity :a))))

--- a/test/cljc/schema/core_test.cljc
+++ b/test/cljc/schema/core_test.cljc
@@ -1634,8 +1634,7 @@
   (s/with-fn-validation (invalid-call! poly-map-dot-arities + [1] 2))
   (s/with-fn-validation (invalid-call! poly-map-dot-arities + [1] [2] 3))
   (s/with-fn-validation (invalid-call! poly-map-dot-arities + [1] [2] [3] 4))
-  (s/with-fn-validation (invalid-call! poly-map-dot-arities + [1] [2] [3] [4] 5))
-)
+  (s/with-fn-validation (invalid-call! poly-map-dot-arities + [1] [2] [3] [4] 5)))
 
 (s/defn :all [x]
   args-shadow-schema-variables :- x

--- a/test/cljc/schema/core_test.cljc
+++ b/test/cljc/schema/core_test.cljc
@@ -700,12 +700,12 @@
 (deftest dotted-fn-schema-test
   (testing "expand dotted template"
     (let [X [s/Int s/Bool]
-          schema (s/=> s/Keyword s/Int s/Int & [X] :.. X)]
+          schema (s/=> s/Keyword s/Int s/Int [X] :.. X)]
       (is (= (s/=> s/Keyword s/Int s/Int [s/Int] [s/Bool])
              schema))))
   (testing "expand AnyDotted"
     (let [X (s/->AnyDotted s/Int)
-          schema (s/=> s/Keyword s/Int s/Int & [X] :.. X)]
+          schema (s/=> s/Keyword s/Int s/Int [X] :.. X)]
       (is (= (s/=> s/Keyword s/Int s/Int & [[s/Int]])
              schema)))))
 
@@ -1622,7 +1622,7 @@
 
 (s/defn :all [X Y :.. Z]
   poly-map-dot :- [Z]
-  [f :- (s/=> Z X & Y :.. Y)
+  [f :- (s/=> Z X Y :.. Y)
    xs :- [X]
    & xss :- [Y] :.. Y]
   (apply map f xs xss))


### PR DESCRIPTION
Adds polymorphic schemas with direct support for `s/{de}fn` etc.

My goal for this first pass is to represent the schema for sequence arities of `clojure.core/map` in one function. We'd need to (at least) look into https://github.com/plumatic/schema/issues/446 for the transducer arities.