### PR TITLE
Address deprecated build dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v5
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ env.ACTION_CACHE_VERSION }}-${{ runner.os }}-maven-${{ hashFiles('**/project.clj') }}
@@ -32,7 +32,7 @@ jobs:
           distribution: 'temurin'
           java-version: 11
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@5.1
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           lein: ${{ env.LEIN_VERSION }}
       - name: Warm deps cache
@@ -42,8 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v5
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ env.ACTION_CACHE_VERSION }}-${{ runner.os }}-maven-${{ hashFiles('**/project.clj') }}
@@ -55,7 +55,7 @@ jobs:
           distribution: 'temurin'
           java-version: 11
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@5.1
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           lein: ${{ env.LEIN_VERSION }}
       - name: Run Eastwood
@@ -64,12 +64,12 @@ jobs:
     needs: setup
     strategy:
       matrix:
-        java: ['8', '11', '17', '18']
+        java: ['8', '11', '17', '21', '24']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - uses: actions/cache@v2
+        uses: actions/checkout@v5
+      - uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ env.ACTION_CACHE_VERSION }}-${{ runner.os }}-maven-${{ hashFiles('**/project.clj') }}
@@ -84,7 +84,7 @@ jobs:
         with:
           node-version: '17.7.2'
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@5.1
+        uses: DeLaGuardo/setup-clojure@13.4
         with:
           lein: ${{ env.LEIN_VERSION }}
       - name: Run JVM tests
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
       - name: Prepare java
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
Some of our build deps are deprecated causing builds to fail.

For example, here's an error message from a [build from August 18th 2025](https://github.com/frenchy64/schema/actions/runs/17047655194/job/48327485861):

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```

I also updated the JVM versions we test against and bumped other outdated Actions.