### PR TITLE
add volatile

### DIFF
--- a/src/cljc/schema/core.cljc
+++ b/src/cljc/schema/core.cljc
@@ -75,7 +75,8 @@
    See the docstrings of defrecord, fn, and defn for more details about how
    to use these macros."
   ;; don't exclude def because it's not a var.
-  (:refer-clojure :exclude [Keyword Symbol Inst atom defprotocol defrecord defn letfn defmethod fn MapEntry ->MapEntry])
+  (:refer-clojure :exclude [Keyword Symbol Inst atom defprotocol defrecord defn letfn defmethod fn MapEntry ->MapEntry
+                            volatile volatile? Volatile ->Volatile])
   (:require
    #?(:clj [clojure.pprint :as pprint])
    [clojure.string :as str]
@@ -698,6 +699,28 @@
   "An atom containing a value matching 'schema'."
   [schema]
   (->Atomic schema))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Volatile schema
+
+(defn- volatile? [x]
+  #?(:clj (instance? clojure.lang.Volatile x)
+     :cljs (satisfies? IVolatile x)))
+
+(macros/defrecord-schema Volatile [schema]
+  Schema
+  (spec [this]
+    (collection/collection-spec
+     (spec/simple-precondition this volatile?)
+     clojure.core/volatile!
+     [(collection/one-element true schema (clojure.core/fn [item-fn coll] (item-fn @coll) nil))]
+     (clojure.core/fn [_ xs _] (clojure.core/volatile! (first xs)))))
+  (explain [this] (list 'volatile (explain schema))))
+
+(clojure.core/defn volatile
+  "A volatile containing a value matching 'schema'."
+  [schema]
+  (->Volatile schema))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/cljc/schema/core_test.cljc
+++ b/test/cljc/schema/core_test.cljc
@@ -437,6 +437,15 @@
     (invalid! s (atom 1))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Atom schemas
+
+(deftest volatile-test
+  (let [s (s/volatile s/Str)]
+    (is (not (s/check s (volatile! "asdf")))) ;; don't expect identity after walking
+    (invalid! s (delay "asdf") "(not (volatile? a-clojure.lang.Delay))")
+    (invalid! s (volatile! 1))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Map Schemas
 
 (deftest uniform-map-test


### PR DESCRIPTION
Volatiles were added in 2015 in Clojure 1.7

We use them a lot in our code, and I wanted to include them in our schemas.

To implement, I just followed what was already there for `atom`, including the tests.

Thank you for reviewing!