### PR TITLE
fix copy error: "Atom schema" -> "Volatile schemas"

### DIFF
--- a/test/cljc/schema/core_test.cljc
+++ b/test/cljc/schema/core_test.cljc
@@ -437,7 +437,7 @@
     (invalid! s (atom 1))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Atom schemas
+;;; Volatile schemas
 
 (deftest volatile-test
   (let [s (s/volatile s/Str)]


### PR DESCRIPTION
In #460, I copied the Atom tests and didn't rename the comment to Volatile